### PR TITLE
Fixed bug to get ipu_config.json from_pretrained path

### DIFF
--- a/optimum/graphcore/ipu_configuration.py
+++ b/optimum/graphcore/ipu_configuration.py
@@ -78,9 +78,12 @@ class IPUConfig(PretrainedConfig):
         cls, pretrained_model_name_or_path: Union[str, os.PathLike], **kwargs
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         orig_transformers_config_name = transformers.file_utils.CONFIG_NAME
+        orig_transformers_full_config_file = transformers.configuration_utils.FULL_CONFIGURATION_FILE
         transformers.configuration_utils.CONFIG_NAME = IPU_CONFIG_NAME
+        transformers.configuration_utils.FULL_CONFIGURATION_FILE = "ipu_config.json"
         ipu_config = super().get_config_dict(pretrained_model_name_or_path, **kwargs)
         transformers.configuration_utils.CONFIG_NAME = orig_transformers_config_name
+        transformers.configuration_utils.FULL_CONFIGURATION_FILE = orig_transformers_full_config_file
         return ipu_config
 
     def to_options(self, for_inference: bool = False) -> poptorch.Options:


### PR DESCRIPTION
Before to get a pretrained ipu_config you had to specify the json file directly:

```
IPUConfig.from_pretrained("/path/to/config/ipu_config.json")
```

Model hub doesn't let you do this and it's not the behaviour of `from_pretrained` for other configs etc.

Now we can just do

```
IPUConfig.from_pretrained("/path/to/config")
```
