### PR TITLE
Remove `require_datasets` from testing utility

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -42,7 +42,6 @@ from transformers.testing_utils import (
     get_gpu_count,
     get_tests_dir,
     is_staging_test,
-    require_datasets,
     require_optuna,
     require_ray,
     require_sentencepiece,
@@ -407,7 +406,6 @@ class IPUTrainerIntegrationPrerunTest(TestCasePlus, IPUTrainerIntegrationCommon)
         trainer.train()
         self.check_trained_model(trainer.model, alternate_seed=True)
 
-    @require_datasets
     def test_trainer_with_datasets(self):
         import datasets
 


### PR DESCRIPTION
`require_datasets` has been removed from `transformers`: see https://github.com/huggingface/transformers/pull/14795