### PR TITLE
Hook removal bugfix

### DIFF
--- a/optimum/graphcore/modeling_utils.py
+++ b/optimum/graphcore/modeling_utils.py
@@ -89,6 +89,7 @@ class PipelineMixin:
 
     def parallelize(self):
         """Transform the model to run in an IPU pipeline."""
+        self._hooks = []
         return self
 
     def deparallelize(self):

--- a/optimum/graphcore/models/bert/modeling_bert.py
+++ b/optimum/graphcore/models/bert/modeling_bert.py
@@ -169,7 +169,7 @@ class PipelinedBertForPreTraining(BertForPreTraining, PipelineMixin):
         - (If enabled) Replaces the word embedding projection with a SerializedLinear layer
         - Adds recomputation checkpoints
         """
-        self._hooks = []
+        super().parallelize()
 
         # Use faster fused-qkv self-attention
         for layer in self.bert.encoder.layer:
@@ -358,7 +358,6 @@ class BertPipelineMixin(PipelineMixin):
         - Adds recomputation checkpoints
         """
         super().parallelize()
-        self._hooks = []
 
         # Use faster fused-qkv self-attention
         for layer in self.bert.encoder.layer:

--- a/optimum/graphcore/models/roberta/modeling_roberta.py
+++ b/optimum/graphcore/models/roberta/modeling_roberta.py
@@ -147,7 +147,6 @@ class RobertaPipelineMixin(PipelineMixin):
         - Adds recomputation checkpoints
         """
         super().parallelize()
-        self._hooks = []
         layer_ipu = _get_layer_ipu(self.config.layers_per_ipu)
 
         logger.info("-------------------- Device Allocation --------------------")

--- a/optimum/graphcore/models/vit/modeling_vit.py
+++ b/optimum/graphcore/models/vit/modeling_vit.py
@@ -49,7 +49,7 @@ def recomputation_checkpoint(module: nn.Module) -> torch.utils.hooks.RemovableHa
 @register(transformers.ViTForImageClassification)
 class PipelinedViTForImageClassification(transformers.ViTForImageClassification, PipelineMixin):
     def parallelize(self):
-        self._hooks = []
+        super().parallelize()
         logger.info("---------- Device Allocation -----------")
         logger.info("Embedding  --> IPU 0")
         self.vit.embeddings = poptorch.BeginBlock(self.vit.embeddings, "Embedding", ipu_id=0)


### PR DESCRIPTION
There's a bug when running BERT and RoBERTa fine-tuning models where after training is finished and you attempt to compile the inference model you get a tracing error in poptorch:

```
First diverging operator:
        Node diff:
                - %qa_outputs : __torch__.poptorch.ops.___torch_mangle_628.Linear = prim::GetAttr[name="qa_outputs"](%self.1)
                ?                                                      ^ -
                + %qa_outputs : __torch__.poptorch.ops.___torch_mangle_842.Linear = prim::GetAttr[name="qa_outputs"](%self.1)
                ?                                                      ^^
```

This was root-caused to us not removing the `outline_attributes` hooks in the `deparallelize` method for these models.
I have fixed this and also done some refactoring of RoBERTa and BERT models to remove repeated code. 