### PR TITLE
Model ipu config attribute

### DIFF
--- a/optimum/graphcore/modeling_utils.py
+++ b/optimum/graphcore/modeling_utils.py
@@ -86,9 +86,9 @@ class PipelineMixin:
     @classmethod
     def from_model(cls, model: nn.Module):
         clone = copy.deepcopy(model)
-        # It is fine because PipelineMixin only adds functionality, it does not add any attribute.
-        # (The only attribute it adds is not used here)
         clone.__class__ = cls
+        # Just needed so that .parallelize() does not throw an error
+        clone.ipu_config = IPUConfig()
         return clone
 
     @property

--- a/optimum/graphcore/modeling_utils.py
+++ b/optimum/graphcore/modeling_utils.py
@@ -93,16 +93,16 @@ class PipelineMixin:
 
     @property
     def ipu_config(self):
-        ipu_config_ = getattr(self, "ipu_config", None)
-        if ipu_config_ is None:
+        _ipu_config = getattr(self, "_ipu_config", None)
+        if _ipu_config is None:
             raise AttributeError("No IPUConfig was found, please set the ipu_config attribute")
-        return ipu_config_
+        return _ipu_config
 
-    @property.setter
+    @ipu_config.setter
     def ipu_config(self, value: IPUConfig):
         if not isinstance(value, IPUConfig):
             raise TypeError(f"ipu_config must be an instance of IPUConfig, but {type(value)} was provided")
-        self.ipu_config = value
+        self._ipu_config = value
 
     def parallelize(self):
         """Transform the model to run in an IPU pipeline."""

--- a/optimum/graphcore/models/bert/modeling_bert.py
+++ b/optimum/graphcore/models/bert/modeling_bert.py
@@ -303,13 +303,13 @@ class BertPipelineMixin(PipelineMixin):
         for layer in self.bert.encoder.layer:
             layer.attention.self.__class__ = BertFusedSelfAttention
 
-        layer_ipu = get_layer_ipu(self.config.layers_per_ipu)
+        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu)
 
         logger.info("-------------------- Device Allocation --------------------")
         logger.info("Embedding --> IPU 0")
-        if self.config.embedding_serialization_factor > 1:
+        if self.ipu_config.embedding_serialization_factor > 1:
             self.bert.embeddings.word_embeddings = SerializedEmbedding(
-                self.bert.embeddings.word_embeddings, self.config.embedding_serialization_factor
+                self.bert.embeddings.word_embeddings, self.ipu_config.embedding_serialization_factor
             )
         self.bert.embeddings = poptorch.BeginBlock(self.bert.embeddings, "Embedding", ipu_id=0)
         hs = outline_attribute(self.bert.embeddings.LayerNorm, "embedding")
@@ -317,7 +317,7 @@ class BertPipelineMixin(PipelineMixin):
 
         for index, layer in enumerate(self.bert.encoder.layer):
             ipu = layer_ipu[index]
-            if self.config.recompute_checkpoint_every_layer and index != self.config.num_hidden_layers - 1:
+            if self.ipu_config.recompute_checkpoint_every_layer and index != self.config.num_hidden_layers - 1:
                 h = recomputation_checkpoint(layer)
                 self._hooks.append(h)
             self.bert.encoder.layer[index] = poptorch.BeginBlock(layer, f"Encoder{index}", ipu_id=ipu)
@@ -336,7 +336,7 @@ class BertPipelineMixin(PipelineMixin):
             layer.attention.self.__class__ = BertSelfAttention
 
         # Deserialize the serialized word embedding
-        if self.config.embedding_serialization_factor > 1:
+        if self.ipu_config.embedding_serialization_factor > 1:
             self.bert.embeddings.word_embeddings = self.bert.embeddings.word_embeddings.deserialize()
         return self
 
@@ -354,7 +354,7 @@ class PipelinedBertForSequenceClassification(BertForSequenceClassification, Bert
 
     def parallelize(self):
         super().parallelize()
-        last_ipu = self.config.ipus_per_replica - 1
+        last_ipu = self.ipu_config.ipus_per_replica - 1
         logger.info(f"Classifier Output --> IPU {last_ipu}")
         self.classifier = poptorch.BeginBlock(self.classifier, "Classifier Output", ipu_id=last_ipu)
         logger.info("-----------------------------------------------------------")
@@ -383,7 +383,7 @@ class PipelinedBertForMultipleChoice(BertForMultipleChoice, BertPipelineMixin):
 
     def parallelize(self):
         super().parallelize()
-        last_ipu = self.config.ipus_per_replica - 1
+        last_ipu = self.ipu_config.ipus_per_replica - 1
         logger.info(f"Classifier Output --> IPU {last_ipu}")
         self.classifier = poptorch.BeginBlock(self.classifier, "Classifier Output", ipu_id=last_ipu)
         logger.info("-----------------------------------------------------------")
@@ -412,7 +412,7 @@ class PipelinedBertForTokenClassification(BertForTokenClassification, BertPipeli
 
     def parallelize(self):
         super().parallelize()
-        last_ipu = self.config.ipus_per_replica - 1
+        last_ipu = self.ipu_config.ipus_per_replica - 1
         logger.info(f"Classifier Output --> IPU {last_ipu}")
         self.classifier = poptorch.BeginBlock(self.classifier, "Classifier Output", ipu_id=last_ipu)
         logger.info("-----------------------------------------------------------")
@@ -441,7 +441,7 @@ class PipelinedBertForQuestionAnswering(BertForQuestionAnswering, BertPipelineMi
 
     def parallelize(self):
         super().parallelize()
-        last_ipu = self.config.ipus_per_replica - 1
+        last_ipu = self.ipu_config.ipus_per_replica - 1
         logger.info(f"QA Outputs --> IPU {last_ipu}")
         self.qa_outputs = poptorch.BeginBlock(self.qa_outputs, "QA Outputs", ipu_id=last_ipu)
         logger.info("-----------------------------------------------------------")

--- a/optimum/graphcore/models/bert/modeling_bert.py
+++ b/optimum/graphcore/models/bert/modeling_bert.py
@@ -86,7 +86,7 @@ class PipelinedBertForPreTraining(BertForPreTraining, PipelineMixin):
             self.cls.predictions.decoder = serialized_decoder
             self.tie_weights()
 
-        layer_ipu = get_layer_ipu(self.config.layers_per_ipu)
+        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu)
 
         logger.info("-------------------- Device Allocation --------------------")
         logger.info("Embedding --> IPU 0")

--- a/optimum/graphcore/models/t5/modeling_t5.py
+++ b/optimum/graphcore/models/t5/modeling_t5.py
@@ -524,7 +524,7 @@ class PipelinedT5ForConditionalGeneration(IPUGenerationMixin, T5ForConditionalGe
         if self.config.tie_word_embeddings:
             # Rescale output before projecting on vocab
             # See https://github.com/tensorflow/mesh/blob/fa19d69eafc9a482aff0b59ddd96b025c0cb207d/mesh_tensorflow/transformer/transformer.py#L586
-            sequence_output = sequence_output * (self.model_dim ** -0.5)
+            sequence_output = sequence_output * (self.model_dim**-0.5)
 
         lm_scale_modifier = getattr(self, "lm_scale_modifier", None)
         if lm_scale_modifier is not None:

--- a/optimum/graphcore/models/vit/modeling_vit.py
+++ b/optimum/graphcore/models/vit/modeling_vit.py
@@ -30,9 +30,9 @@ class PipelinedViTForImageClassification(transformers.ViTForImageClassification,
         logger.info("Embedding  --> IPU 0")
         self.vit.embeddings = poptorch.BeginBlock(self.vit.embeddings, "Embedding", ipu_id=0)
 
-        layer_ipu = get_layer_ipu(self.config.layers_per_ipu)
+        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu)
         for index, layer in enumerate(self.vit.encoder.layer):
-            if self.config.recompute_checkpoint_every_layer:
+            if self.ipu_config.recompute_checkpoint_every_layer:
                 # Put checkpoints on every encoder layer
                 h = recomputation_checkpoint(layer)
                 self._hooks.append(h)


### PR DESCRIPTION
# What does this PR do?

Currently, the `IPUConfig` dict is merged into the `model.config` attribute. This is bad because when saving the model and its configuration, the IPU config content is saved in the model configuration at the same time. 

To avoid that, an `ipu_config` attribute needs to be added to pipelined models. It's already be taken care of with the class methods from `PipelineMixin`, and for the case in which a pipeline object is instantiated from the class constructor, the user should get an error when trying to parallelize the model if the attribute was not set beforehand.

We could also add an optional `ipu_config` argument to the parallelize method to allow the user to provide this config directly instead of doing:
```python
pipelined_model.ipu_config = IPUConfig.from_pretrained(....)
pipelined_model.parallelize()
``` 

@jimypbr wdyt?
