### PR TITLE
Update the allowed pod_types

### DIFF
--- a/optimum/graphcore/ipu_configuration.py
+++ b/optimum/graphcore/ipu_configuration.py
@@ -29,7 +29,7 @@ from poptorch import Options, OutputMode
 logger = logging.get_logger(__name__)
 
 IPU_CONFIG_NAME = "ipu_config.json"
-ALLOWED_POD_TYPES = ["pod4", "pod16", "pod64", "pod128", "pod256"]
+ALLOWED_POD_TYPES = ["pod4", "pod8", "pod16", "pod32", "pod64"]
 
 
 class IPUConfig(BaseConfig):


### PR DESCRIPTION
# What does this PR do?

Change the allowed pod types to pods: 4, 8, 16, 32, 64.
We don't support 128 and 256 yet because they require poddist/MPI to run.

