### PR TITLE
Test and tool to check that transformers and optimum examples match

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -1,8 +1,6 @@
 name: examples
 
 on:
-  push:
-    branches: [ main ]
   schedule:
     # At the end of everyday
     - cron: 0 0 * * *

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -40,4 +40,5 @@ jobs:
         . ${SDK_PATH}/poplar-ubuntu_18_04-2\.4\.0**/enable.sh
         . ${SDK_PATH}/popart-ubuntu_18_04-*2\.4\.0*/enable.sh
         export RUN_SLOW=true
+        pytest tests/test_examples_match_transformers.py
         pytest tests/test_examples.py

--- a/.github/workflows/test-general.yml
+++ b/.github/workflows/test-general.yml
@@ -1,4 +1,4 @@
-name: run_tests_ipu
+name: tests
 
 on:
   push:

--- a/examples/language-modeling/run_mlm.py
+++ b/examples/language-modeling/run_mlm.py
@@ -507,6 +507,12 @@ def main():
         pad_to_multiple_of=None,
     )
 
+    if training_args.do_eval and not training_args.prediction_loss_only:
+        logging.warning(
+            "Because pipelined models return only the loss sometimes (due to performance reasons), evaluation might not"
+            " work as expected, set --prediction_loss_only to fix that."
+        )
+
     # Initialize our Trainer
     trainer = IPUTrainer(
         model=model,

--- a/examples/multiple-choice/run_swag.py
+++ b/examples/multiple-choice/run_swag.py
@@ -48,7 +48,7 @@ from transformers.utils import check_min_version
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-check_min_version("4.13.0.dev0")
+check_min_version("4.18.0.dev0")
 
 logger = logging.getLogger(__name__)
 
@@ -152,21 +152,20 @@ class DataCollatorForMultipleChoice:
     Data collator that will dynamically pad the inputs for multiple choice received.
 
     Args:
-        tokenizer (:class:`~transformers.PreTrainedTokenizer` or :class:`~transformers.PreTrainedTokenizerFast`):
+        tokenizer ([`PreTrainedTokenizer`] or [`PreTrainedTokenizerFast`]):
             The tokenizer used for encoding the data.
-        padding (:obj:`bool`, :obj:`str` or :class:`~transformers.file_utils.PaddingStrategy`, `optional`, defaults to :obj:`True`):
+        padding (`bool`, `str` or [`~file_utils.PaddingStrategy`], *optional*, defaults to `True`):
             Select a strategy to pad the returned sequences (according to the model's padding side and padding index)
             among:
 
-            * :obj:`True` or :obj:`'longest'`: Pad to the longest sequence in the batch (or no padding if only a single
-              sequence if provided).
-            * :obj:`'max_length'`: Pad to a maximum length specified with the argument :obj:`max_length` or to the
-              maximum acceptable input length for the model if that argument is not provided.
-            * :obj:`False` or :obj:`'do_not_pad'` (default): No padding (i.e., can output a batch with sequences of
-              different lengths).
-        max_length (:obj:`int`, `optional`):
-            Maximum length of the returned list and optionally padding length (see above).
-        pad_to_multiple_of (:obj:`int`, `optional`):
+            - `True` or `'longest'`: Pad to the longest sequence in the batch (or no padding if only a single sequence
+              if provided).
+            - `'max_length'`: Pad to a maximum length specified with the argument `max_length` or to the maximum
+              acceptable input length for the model if that argument is not provided.
+            - `False` or `'do_not_pad'` (default): No padding (i.e., can output a batch with sequences of different
+              lengths).
+        max_length (`int`, *optional*):
+        pad_to_multiple_of (`int`, *optional*):
             If set will pad the sequence to a multiple of the provided value.
 
             This is especially useful to enable the use of Tensor Cores on NVIDIA hardware with compute capability >=

--- a/examples/question-answering/run_qa.py
+++ b/examples/question-answering/run_qa.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Fine-tuning the library models for question answering.
+Fine-tuning the library models for question answering using a slightly adapted version of the 🤗 Trainer.
 """
 # You can also adapt this script on your own question answering task. Pointers for this are left as comments.
 
@@ -50,7 +50,7 @@ from utils_qa import postprocess_qa_predictions
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-check_min_version("4.12.0.dev0")
+check_min_version("4.18.0.dev0")
 
 require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/question-answering/requirements.txt")
 
@@ -227,11 +227,6 @@ def main():
     transformers.utils.logging.enable_default_handler()
     transformers.utils.logging.enable_explicit_format()
 
-    # Log on each process the small summary:
-    # logger.warning(
-    #     f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
-    #     + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
-    # )
     logger.info(f"Training/evaluation parameters {training_args}")
 
     # Detecting last checkpoint.
@@ -287,7 +282,6 @@ def main():
     # Distributed training:
     # The .from_pretrained methods guarantee that only one local process can concurrently
     # download model & vocab.
-
     config = AutoConfig.from_pretrained(
         model_args.config_name if model_args.config_name else model_args.model_name_or_path,
         cache_dir=model_args.cache_dir,

--- a/examples/summarization/run_summarization.py
+++ b/examples/summarization/run_summarization.py
@@ -52,7 +52,7 @@ from transformers.utils.versions import require_version
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-check_min_version("4.16.0.dev0")
+check_min_version("4.18.0.dev0")
 
 require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/summarization/requirements.txt")
 
@@ -484,8 +484,6 @@ def main():
                 inputs.append(examples[text_column][i])
                 targets.append(examples[summary_column][i])
 
-        inputs = examples[text_column]
-        targets = examples[summary_column]
         inputs = [prefix + inp for inp in inputs]
         model_inputs = tokenizer(inputs, max_length=data_args.max_source_length, padding=padding, truncation=True)
 
@@ -559,7 +557,6 @@ def main():
         tokenizer,
         model=model,
         label_pad_token_id=label_pad_token_id,
-        # pad_to_multiple_of=8 if training_args.fp16 else None,
         pad_to_multiple_of=None,
     )
 

--- a/examples/text-classification/run_glue.py
+++ b/examples/text-classification/run_glue.py
@@ -47,7 +47,7 @@ from transformers.utils.versions import require_version
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-check_min_version("4.13.0.dev0")
+check_min_version("4.18.0.dev0")
 
 require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/text-classification/requirements.txt")
 
@@ -458,7 +458,8 @@ def main():
         else:
             return {"accuracy": (preds == p.label_ids).astype(np.float32).mean().item()}
 
-    # Data collator will default to DataCollatorWithPadding, so we change it if we already did the padding.
+    # Data collator will default to DataCollatorWithPadding when the tokenizer is passed to Trainer, so we change it if
+    # we already did the padding.
     if data_args.pad_to_max_length:
         data_collator = default_data_collator
     else:

--- a/examples/text-classification/run_xnli.py
+++ b/examples/text-classification/run_xnli.py
@@ -47,7 +47,7 @@ from transformers.utils.versions import require_version
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-check_min_version("4.13.0.dev0")
+check_min_version("4.18.0.dev0")
 
 require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/text-classification/requirements.txt")
 

--- a/examples/token-classification/run_ner.py
+++ b/examples/token-classification/run_ner.py
@@ -38,6 +38,7 @@ from transformers import (
     AutoTokenizer,
     DataCollatorForTokenClassification,
     HfArgumentParser,
+    PretrainedConfig,
     PreTrainedTokenizerFast,
     set_seed,
 )
@@ -47,7 +48,7 @@ from transformers.utils.versions import require_version
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-check_min_version("4.13.0.dev0")
+check_min_version("4.18.0.dev0")
 
 require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/token-classification/requirements.txt")
 
@@ -289,22 +290,17 @@ def main():
         label_list.sort()
         return label_list
 
-    if isinstance(features[label_column_name].feature, ClassLabel):
+    # If the labels are of type ClassLabel, they are already integers and we have the map stored somewhere.
+    # Otherwise, we have to get the list of labels manually.
+    labels_are_int = isinstance(features[label_column_name].feature, ClassLabel)
+    if labels_are_int:
         label_list = features[label_column_name].feature.names
-        # No need to convert the labels since they are already ints.
         label_to_id = {i: i for i in range(len(label_list))}
     else:
         label_list = get_label_list(raw_datasets["train"][label_column_name])
         label_to_id = {l: i for i, l in enumerate(label_list)}
-    num_labels = len(label_list)
 
-    # Map that sends B-Xxx label to its I-Xxx counterpart
-    b_to_i_label = []
-    for idx, label in enumerate(label_list):
-        if label.startswith("B-") and label.replace("B-", "I-") in label_list:
-            b_to_i_label.append(label_list.index(label.replace("B-", "I-")))
-        else:
-            b_to_i_label.append(idx)
+    num_labels = len(label_list)
 
     # Load pretrained model and tokenizer
     #
@@ -314,8 +310,6 @@ def main():
     config = AutoConfig.from_pretrained(
         model_args.config_name if model_args.config_name else model_args.model_name_or_path,
         num_labels=num_labels,
-        label2id=label_to_id,
-        id2label={i: l for l, i in label_to_id.items()},
         finetuning_task=data_args.task_name,
         cache_dir=model_args.cache_dir,
         revision=model_args.model_revision,
@@ -363,6 +357,35 @@ def main():
             "at https://huggingface.co/transformers/index.html#supported-frameworks to find the model types that meet this "
             "requirement"
         )
+
+    # Model has labels -> use them.
+    if model.config.label2id != PretrainedConfig(num_labels=num_labels).label2id:
+        if list(sorted(model.config.label2id.keys())) == list(sorted(label_list)):
+            # Reorganize `label_list` to match the ordering of the model.
+            if labels_are_int:
+                label_to_id = {i: int(model.config.label2id[l]) for i, l in enumerate(label_list)}
+                label_list = [model.config.id2label[i] for i in range(num_labels)]
+            else:
+                label_list = [model.config.id2label[i] for i in range(num_labels)]
+                label_to_id = {l: i for i, l in enumerate(label_list)}
+        else:
+            logger.warning(
+                "Your model seems to have been trained with labels, but they don't match the dataset: ",
+                f"model labels: {list(sorted(model.config.label2id.keys()))}, dataset labels: {list(sorted(label_list))}."
+                "\nIgnoring the model labels as a result.",
+            )
+
+    # Set the correspondences label/ID inside the model config
+    model.config.label2id = {l: i for i, l in enumerate(label_list)}
+    model.config.id2label = {i: l for i, l in enumerate(label_list)}
+
+    # Map that sends B-Xxx label to its I-Xxx counterpart
+    b_to_i_label = []
+    for idx, label in enumerate(label_list):
+        if label.startswith("B-") and label.replace("B-", "I-") in label_list:
+            b_to_i_label.append(label_list.index(label.replace("B-", "I-")))
+        else:
+            b_to_i_label.append(idx)
 
     # Preprocessing the dataset
     # Padding strategy

--- a/examples/translation/run_translation.py
+++ b/examples/translation/run_translation.py
@@ -51,7 +51,7 @@ from transformers.utils.versions import require_version
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-check_min_version("4.16.0.dev0")
+check_min_version("4.18.0.dev0")
 
 require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/translation/requirements.txt")
 
@@ -257,11 +257,6 @@ def main():
     transformers.utils.logging.enable_default_handler()
     transformers.utils.logging.enable_explicit_format()
 
-    # Log on each process the small summary:
-    # logger.warning(
-    #     f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
-    #     + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
-    # )
     logger.info(f"Training/evaluation parameters {training_args}")
 
     if data_args.source_prefix is None and model_args.model_name_or_path in [
@@ -493,7 +488,6 @@ def main():
             tokenizer,
             model=model,
             label_pad_token_id=label_pad_token_id,
-            # pad_to_multiple_of=8 if training_args.fp16 else None,
             pad_to_multiple_of=None,
         )
 

--- a/optimum/graphcore/ipu_configuration.py
+++ b/optimum/graphcore/ipu_configuration.py
@@ -56,9 +56,8 @@ class IPUConfig(BaseConfig):
         self.enable_half_first_order_momentum = kwargs.pop("enable_half_first_order_momentum", False)
         self.enable_half_partials = kwargs.pop("enable_half_partials", False)
 
-        # TODO: is it actually used?
         self.executable_cache_dir = kwargs.pop("executable_cache_dir", "")
-        self.profile_dir = kwargs.pop("profile_dir", None)
+        self.profile_dir = kwargs.pop("profile_dir", "")
 
         self.embedding_serialization_factor = kwargs.pop("embedding_serialization_factor", 1)
 
@@ -187,7 +186,7 @@ class IPUConfig(BaseConfig):
         opts.setAvailableMemoryProportion(mem_prop)
 
         # Enable caching the compiled executable to disk
-        if self.executable_cache_dir:
+        if self.executable_cache_dir and self.executable_cache_dir != "disabled":
             opts.enableExecutableCaching(self.executable_cache_dir)
 
         # Enable stochastic rounding (recommended for training with FP16)

--- a/optimum/graphcore/ipu_configuration.py
+++ b/optimum/graphcore/ipu_configuration.py
@@ -57,7 +57,7 @@ class IPUConfig(BaseConfig):
         self.enable_half_partials = kwargs.pop("enable_half_partials", False)
 
         # TODO: is it actually used?
-        self.executable_cache_dir = kwargs.pop("executable_cache_dir", None)
+        self.executable_cache_dir = kwargs.pop("executable_cache_dir", "")
         self.profile_dir = kwargs.pop("profile_dir", None)
 
         self.embedding_serialization_factor = kwargs.pop("embedding_serialization_factor", 1)

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ install_requires = [
     "pytest",
     "pytest-pythonpath",
     "parameterized",
+    "GitPython",
 ]
 
 setup(

--- a/tests/create_diff_file_for_example.py
+++ b/tests/create_diff_file_for_example.py
@@ -56,6 +56,8 @@ def _colorize_lines(content):
     }
     end_color = "\033[0;0m"
     for i, line in enumerate(lines):
+        if not line:
+            continue
         start_char = color_mapping.get(line[0], color_mapping["default"])
         lines[i] = "".join([start_char, line, end_color])
     return "\n".join(lines)
@@ -72,6 +74,8 @@ def create_diff_content(raw_diff: str) -> str:
         if keep_diff == "n":
             continue
         final_diff.append(m1.group(0) + content)
+    # To end with a return to line character, just as the diff function.
+    final_diff.append("")
     return "\n".join(final_diff)
 
 

--- a/tests/create_diff_file_for_example.py
+++ b/tests/create_diff_file_for_example.py
@@ -68,14 +68,16 @@ def create_diff_content(raw_diff: str) -> str:
     final_diff = []
     for m1, m2 in zip(matches, matches[1:] + [None]):
         start, end = m1.span()[0], m2.span()[0] if m2 is not None else None
-        content = raw_diff[start:end].strip()
+        if end is not None and raw_diff[end - 1] == "\n":
+            end = end - 1
+        content = raw_diff[start:end]
         print(_colorize_lines(content))
         keep_diff = _ask_yes_or_no_question("Keep this diff")
         if keep_diff == "n":
             continue
-        final_diff.append(m1.group(0) + content)
+        final_diff.append(content)
     # To end with a return to line character, just as the diff function.
-    final_diff.append("")
+    # final_diff.append("")
     return "\n".join(final_diff)
 
 

--- a/tests/create_diff_file_for_example.py
+++ b/tests/create_diff_file_for_example.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2018 the HuggingFace Inc. team.
+# Copyright 2022 the HuggingFace Inc. team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import re
 import subprocess
 from argparse import ArgumentParser
 from pathlib import Path
+
 
 DIFF_DIRECTORY = Path("tests/examples")
 
@@ -38,7 +39,6 @@ def _ask_yer_or_no_question(message: str) -> str:
 
 def diff(filename1: Path, filename2: Path) -> str:
     if not filename1.exists() or not filename2.exists():
-        import pdb; pdb.set_trace()
         raise FileNotFoundError("Cannot compute the diff because at least of one the file does not exist.")
     cmd_line = ["diff", str(filename1), str(filename2)]
     p = subprocess.Popen(cmd_line, stdout=subprocess.PIPE)
@@ -66,7 +66,7 @@ def create_diff_content(raw_diff: str) -> str:
     final_diff = []
     for m1, m2 in zip(matches, matches[1:] + [None]):
         start, end = m1.span()[1], m2.span()[0] if m2 is not None else None
-        content = raw_diff[start: end].strip()
+        content = raw_diff[start:end].strip()
         print(_colorize_lines(content))
         keep_diff = _ask_yer_or_no_question("Keep this diff")
         if keep_diff == "n":
@@ -76,7 +76,9 @@ def create_diff_content(raw_diff: str) -> str:
 
 
 def parse_args():
-    parser = ArgumentParser(description="Tool to create or update a diff file between transformers and optimum examples.")
+    parser = ArgumentParser(
+        description="Tool to create or update a diff file between transformers and optimum examples."
+    )
     parser.add_argument("--transformers", type=Path, required=True, help="The path to the transformers example")
     parser.add_argument("--optimum", type=Path, required=True, help="The path to the optimum example")
     return parser.parse_args()

--- a/tests/create_diff_file_for_example.py
+++ b/tests/create_diff_file_for_example.py
@@ -1,0 +1,113 @@
+# coding=utf-8
+# Copyright 2018 the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Tool to create or update a diff file between transformers and optimum examples. """
+
+import re
+import subprocess
+from argparse import ArgumentParser
+from pathlib import Path
+
+DIFF_DIRECTORY = Path("tests/examples")
+
+
+def _ask_yer_or_no_question(message: str) -> str:
+    if message[-1] == "?":
+        message = message[:-1]
+    message = f"{message} (y/n) ? "
+    continue_ = True
+    while continue_:
+        res = input(message)
+        if res not in ["y", "n"]:
+            print(f"You must answer by either y (yes) or n (no), but {res} was provided.\n")
+        else:
+            continue_ = False
+    return res
+
+
+def diff(filename1: Path, filename2: Path) -> str:
+    if not filename1.exists() or not filename2.exists():
+        import pdb; pdb.set_trace()
+        raise FileNotFoundError("Cannot compute the diff because at least of one the file does not exist.")
+    cmd_line = ["diff", str(filename1), str(filename2)]
+    p = subprocess.Popen(cmd_line, stdout=subprocess.PIPE)
+    outs, _ = p.communicate()
+    return outs.decode("utf-8")
+
+
+def _colorize_lines(content):
+    lines = content.split("\n")
+    color_mapping = {
+        "<": "\033[0;31m",  # Red
+        ">": "\033[0;32m",  # Green
+        "-": "",
+        "default": "\033[0;36m",  # Blue
+    }
+    end_color = "\033[0;0m"
+    for i, line in enumerate(lines):
+        start_char = color_mapping.get(line[0], color_mapping["default"])
+        lines[i] = "".join([start_char, line, end_color])
+    return "\n".join(lines)
+
+
+def create_diff_content(raw_diff: str) -> str:
+    matches = list(re.finditer(r"^[^><-]+", raw_diff, flags=re.MULTILINE))
+    final_diff = []
+    for m1, m2 in zip(matches, matches[1:] + [None]):
+        start, end = m1.span()[1], m2.span()[0] if m2 is not None else None
+        content = raw_diff[start: end].strip()
+        print(_colorize_lines(content))
+        keep_diff = _ask_yer_or_no_question("Keep this diff")
+        if keep_diff == "n":
+            continue
+        final_diff.append(m1.group(0) + content)
+    return "\n".join(final_diff)
+
+
+def parse_args():
+    parser = ArgumentParser(description="Tool to create or update a diff file between transformers and optimum examples.")
+    parser.add_argument("--transformers", type=Path, required=True, help="The path to the transformers example")
+    parser.add_argument("--optimum", type=Path, required=True, help="The path to the optimum example")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    raw_diff = diff(args.transformers, args.optimum)
+    print(f"Creating the diff file between {args.transformers} and {args.optimum}:\n")
+    final_diff = create_diff_content(raw_diff)
+    print(f"Difference between {args.transformers} and {args.optimum}:\n")
+    print(_colorize_lines(final_diff))
+    print("\n")
+
+    default_filename = DIFF_DIRECTORY / f"{args.transformers.stem}.txt"
+    filename = input(f"Would you like to save this file at {default_filename} (y/n/other path)? ")
+    if filename == "y":
+        filename = default_filename
+    if filename != "n":
+        filename = Path(filename)
+        should_override = True
+        if filename.exists():
+            should_override = _ask_yer_or_no_question("This file already exists, do you want to overwrite it")
+            should_override = should_override == "y"
+
+        if should_override:
+            with open(filename, "w") as fp:
+                fp.write(final_diff)
+
+            print(f"Content saved at: {filename}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/create_diff_file_for_example.py
+++ b/tests/create_diff_file_for_example.py
@@ -76,8 +76,6 @@ def create_diff_content(raw_diff: str) -> str:
         if keep_diff == "n":
             continue
         final_diff.append(content)
-    # To end with a return to line character, just as the diff function.
-    # final_diff.append("")
     return "\n".join(final_diff)
 
 

--- a/tests/create_diff_file_for_example.py
+++ b/tests/create_diff_file_for_example.py
@@ -23,7 +23,7 @@ from pathlib import Path
 DIFF_DIRECTORY = Path("tests/examples")
 
 
-def _ask_yer_or_no_question(message: str) -> str:
+def _ask_yes_or_no_question(message: str) -> str:
     if message[-1] == "?":
         message = message[:-1]
     message = f"{message} (y/n) ? "
@@ -68,7 +68,7 @@ def create_diff_content(raw_diff: str) -> str:
         start, end = m1.span()[1], m2.span()[0] if m2 is not None else None
         content = raw_diff[start:end].strip()
         print(_colorize_lines(content))
-        keep_diff = _ask_yer_or_no_question("Keep this diff")
+        keep_diff = _ask_yes_or_no_question("Keep this diff")
         if keep_diff == "n":
             continue
         final_diff.append(m1.group(0) + content)
@@ -101,7 +101,7 @@ def main():
         filename = Path(filename)
         should_override = True
         if filename.exists():
-            should_override = _ask_yer_or_no_question("This file already exists, do you want to overwrite it")
+            should_override = _ask_yes_or_no_question("This file already exists, do you want to overwrite it")
             should_override = should_override == "y"
 
         if should_override:

--- a/tests/create_diff_file_for_example.py
+++ b/tests/create_diff_file_for_example.py
@@ -67,7 +67,7 @@ def create_diff_content(raw_diff: str) -> str:
     matches = list(re.finditer(r"^[^><-]+", raw_diff, flags=re.MULTILINE))
     final_diff = []
     for m1, m2 in zip(matches, matches[1:] + [None]):
-        start, end = m1.span()[1], m2.span()[0] if m2 is not None else None
+        start, end = m1.span()[0], m2.span()[0] if m2 is not None else None
         content = raw_diff[start:end].strip()
         print(_colorize_lines(content))
         keep_diff = _ask_yes_or_no_question("Keep this diff")

--- a/tests/examples/run_glue.txt
+++ b/tests/examples/run_glue.txt
@@ -1,0 +1,28 @@
+30a31,32
+> from optimum.graphcore import IPUConfig, IPUTrainer
+> from optimum.graphcore import IPUTrainingArguments as TrainingArguments
+39,40d40
+<     Trainer,
+<     TrainingArguments,
+216,220d215
+<     # Log on each process the small summary:
+<     logger.warning(
+<         f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
+<         + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
+<     )
+322a318,323
+>     ipu_config = IPUConfig.from_pretrained(
+>         training_args.ipu_config_name if training_args.ipu_config_name else model_args.model_name_or_path,
+>         cache_dir=model_args.cache_dir,
+>         revision=model_args.model_revision,
+>         use_auth_token=True if model_args.use_auth_token else None,
+>     )
+464,465d464
+<     elif training_args.fp16:
+<         data_collator = DataCollatorWithPadding(tokenizer, pad_to_multiple_of=8)
+470c469
+<     trainer = Trainer(
+---
+>     trainer = IPUTrainer(
+471a471
+>         ipu_config=ipu_config,

--- a/tests/examples/run_image_classification.txt
+++ b/tests/examples/run_image_classification.txt
@@ -1,0 +1,27 @@
+37a38,39
+> from optimum.graphcore import IPUConfig, IPUTrainer
+> from optimum.graphcore import IPUTrainingArguments as TrainingArguments
+44,45d45
+<     Trainer,
+<     TrainingArguments,
+181,185d180
+<     # Log on each process the small summary:
+<     logger.warning(
+<         f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
+<         + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
+<     )
+245a241,248
+> 
+>     ipu_config = IPUConfig.from_pretrained(
+>         training_args.ipu_config_name if training_args.ipu_config_name else model_args.model_name_or_path,
+>         cache_dir=model_args.cache_dir,
+>         revision=model_args.model_revision,
+>         use_auth_token=True if model_args.use_auth_token else None,
+>     )
+> 
+311c314
+<     trainer = Trainer(
+---
+>     trainer = IPUTrainer(
+312a316
+>         ipu_config=ipu_config,

--- a/tests/examples/run_mlm.txt
+++ b/tests/examples/run_mlm.txt
@@ -29,13 +29,20 @@
 <         pad_to_multiple_of=8 if pad_to_multiple_of_8 else None,
 ---
 >         pad_to_multiple_of=None,
-510c511
+508a510,515
+>     if training_args.do_eval and not training_args.prediction_loss_only:
+>         logging.warning(
+>             "Because pipelined models return only the loss sometimes (due to performance reasons), evaluation might not"
+>             " work as expected, set --prediction_loss_only to fix that."
+>         )
+> 
+510c517
 <     trainer = Trainer(
 ---
 >     trainer = IPUTrainer(
-511a513
+511a519
 >         ipu_config=ipu_config,
-517,520c519,520
+517,520c525,526
 <         compute_metrics=compute_metrics if training_args.do_eval and not is_torch_tpu_available() else None,
 <         preprocess_logits_for_metrics=preprocess_logits_for_metrics
 <         if training_args.do_eval and not is_torch_tpu_available()

--- a/tests/examples/run_mlm.txt
+++ b/tests/examples/run_mlm.txt
@@ -1,0 +1,45 @@
+35a36,38
+> from optimum.graphcore import IPUConfig, IPUTrainer
+> from optimum.graphcore import IPUTrainingArguments as TrainingArguments
+> from optimum.graphcore.data import DataCollatorForLanguageModelingWithMaxTokensMasked, pad_on_batch_axis
+44,46d46
+<     Trainer,
+<     TrainingArguments,
+<     is_torch_tpu_available,
+228,232d227
+<     # Log on each process the small summary:
+<     logger.warning(
+<         f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
+<         + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
+<     )
+332a328,334
+>     if training_args.ipu_config_name:
+>         ipu_config = IPUConfig.from_pretrained(training_args.ipu_config_name, **config_kwargs)
+>     elif model_args.model_name_or_path:
+>         ipu_config = IPUConfig.from_pretrained(model_args.model_name_or_path, **config_kwargs)
+>     else:
+>         raise RuntimeError("You must provide an IPUConfig")
+> 
+502,503c504
+<     pad_to_multiple_of_8 = data_args.line_by_line and training_args.fp16 and not data_args.pad_to_max_length
+<     data_collator = DataCollatorForLanguageModeling(
+---
+>     data_collator = DataCollatorForLanguageModelingWithMaxTokensMasked(
+506c507
+<         pad_to_multiple_of=8 if pad_to_multiple_of_8 else None,
+---
+>         pad_to_multiple_of=None,
+510c511
+<     trainer = Trainer(
+---
+>     trainer = IPUTrainer(
+511a513
+>         ipu_config=ipu_config,
+517,520c519,520
+<         compute_metrics=compute_metrics if training_args.do_eval and not is_torch_tpu_available() else None,
+<         preprocess_logits_for_metrics=preprocess_logits_for_metrics
+<         if training_args.do_eval and not is_torch_tpu_available()
+<         else None,
+---
+>         compute_metrics=compute_metrics if training_args.do_eval else None,
+>         preprocess_logits_for_metrics=preprocess_logits_for_metrics if training_args.do_eval else None,

--- a/tests/examples/run_ner.txt
+++ b/tests/examples/run_ner.txt
@@ -1,0 +1,39 @@
+32a33,34
+> from optimum.graphcore import IPUConfig, IPUTrainer
+> from optimum.graphcore import IPUTrainingArguments as TrainingArguments
+41,42d42
+<     Trainer,
+<     TrainingArguments,
+135c135
+<         default=False,
+---
+>         default=True,
+215,219d214
+<     # Log on each process the small summary:
+<     logger.warning(
+<         f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
+<         + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
+<     )
+322a318,323
+>     ipu_config = IPUConfig.from_pretrained(
+>         training_args.ipu_config_name if training_args.ipu_config_name else model_args.model_name_or_path,
+>         cache_dir=model_args.cache_dir,
+>         revision=model_args.model_revision,
+>         use_auth_token=True if model_args.use_auth_token else None,
+>     )
+391a393,397
+>     if not data_args.pad_to_max_length:
+>         logging.warning(
+>             "Not padding to max length might lead to batches with difference sequence lengths, which might not work as"
+>             "expected on IPUs"
+>         )
+475c481
+<     data_collator = DataCollatorForTokenClassification(tokenizer, pad_to_multiple_of=8 if training_args.fp16 else None)
+---
+>     data_collator = DataCollatorForTokenClassification(tokenizer, pad_to_multiple_of=None)
+514c520
+<     trainer = Trainer(
+---
+>     trainer = IPUTrainer(
+515a522
+>         ipu_config=ipu_config,

--- a/tests/examples/run_qa.txt
+++ b/tests/examples/run_qa.txt
@@ -1,0 +1,36 @@
+30a31,33
+> from optimum.graphcore import IPUConfig
+> from optimum.graphcore import IPUTrainingArguments as TrainingArguments
+> from optimum.graphcore.data import pad_on_batch_axis
+40d42
+<     TrainingArguments,
+228,232d229
+<     # Log on each process the small summary:
+<     logger.warning(
+<         f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
+<         + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
+<     )
+293a291,297
+>     ipu_config = IPUConfig.from_pretrained(
+>         training_args.ipu_config_name if training_args.ipu_config_name else model_args.model_name_or_path,
+>         cache_dir=model_args.cache_dir,
+>         revision=model_args.model_revision,
+>         use_auth_token=True if model_args.use_auth_token else None,
+>     )
+> 
+536a541,553
+>     if training_args.do_train and training_args.pad_on_batch_axis:
+>         logger.info(
+>             "Padding on batch axis enabled, each batch feeded to the compiled model during training will have the proper size"
+>         )
+>         data_collator_wrapper = pad_on_batch_axis(
+>             training_args.per_device_train_batch_size * ipu_config.batch_size_factor(),
+>             {
+>                 k: data_args.max_seq_length if k in ["start_positions", "end_positions"] else 0
+>                 for k in train_dataset.column_names
+>             },
+>         )
+>         data_collator = data_collator_wrapper(data_collator)
+> 
+570a588
+>         ipu_config=ipu_config,

--- a/tests/examples/run_summarization.txt
+++ b/tests/examples/run_summarization.txt
@@ -1,0 +1,29 @@
+33a34,35
+> from optimum.graphcore import IPUConfig, IPUSeq2SeqTrainer
+> from optimum.graphcore import IPUSeq2SeqTrainingArguments as Seq2SeqTrainingArguments
+44,45d45
+<     Seq2SeqTrainer,
+<     Seq2SeqTrainingArguments,
+296,300d295
+<     # Log on each process the small summary:
+<     logger.warning(
+<         f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
+<         + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
+<     )
+372a368,373
+>     ipu_config = IPUConfig.from_pretrained(
+>         training_args.ipu_config_name if training_args.ipu_config_name else model_args.model_name_or_path,
+>         cache_dir=model_args.cache_dir,
+>         revision=model_args.model_revision,
+>         use_auth_token=True if model_args.use_auth_token else None,
+>     )
+559c560
+<         pad_to_multiple_of=8 if training_args.fp16 else None,
+---
+>         pad_to_multiple_of=None,
+598c599
+<     trainer = Seq2SeqTrainer(
+---
+>     trainer = IPUSeq2SeqTrainer(
+599a601
+>         ipu_config=ipu_config,

--- a/tests/examples/run_swag.txt
+++ b/tests/examples/run_swag.txt
@@ -1,0 +1,42 @@
+33a34,35
+> from optimum.graphcore import IPUConfig, IPUTrainer
+> from optimum.graphcore import IPUTrainingArguments as TrainingArguments
+39,40d40
+<     Trainer,
+<     TrainingArguments,
+118c118
+<         default=False,
+---
+>         default=True,
+168d167
+<             Maximum length of the returned list and optionally padding length (see above).
+232,236d230
+<     # Log on each process the small summary:
+<     logger.warning(
+<         f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
+<         + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
+<     )
+290a285,290
+>     ipu_config = IPUConfig.from_pretrained(
+>         training_args.ipu_config_name if training_args.ipu_config_name else model_args.model_name_or_path,
+>         cache_dir=model_args.cache_dir,
+>         revision=model_args.model_revision,
+>         use_auth_token=True if model_args.use_auth_token else None,
+>     )
+383c383
+<         else DataCollatorForMultipleChoice(tokenizer=tokenizer, pad_to_multiple_of=8 if training_args.fp16 else None)
+---
+>         else DataCollatorForMultipleChoice(tokenizer=tokenizer, pad_to_multiple_of=None)
+385a386,391
+>     if not data_args.pad_to_max_length:
+>         logging.warning(
+>             "Not padding to max length might lead to batches with difference sequence lengths, which might not work as"
+>             "expected on IPUs"
+>         )
+> 
+393c399
+<     trainer = Trainer(
+---
+>     trainer = IPUTrainer(
+394a401
+>         ipu_config=ipu_config,

--- a/tests/examples/run_translation.txt
+++ b/tests/examples/run_translation.txt
@@ -1,0 +1,29 @@
+31a32,33
+> from optimum.graphcore import IPUConfig, IPUSeq2SeqTrainer
+> from optimum.graphcore import IPUSeq2SeqTrainingArguments as Seq2SeqTrainingArguments
+43,44d44
+<     Seq2SeqTrainer,
+<     Seq2SeqTrainingArguments,
+260,264d259
+<     # Log on each process the small summary:
+<     logger.warning(
+<         f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
+<         + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
+<     )
+336a332,337
+>     ipu_config = IPUConfig.from_pretrained(
+>         training_args.ipu_config_name if training_args.ipu_config_name else model_args.model_name_or_path,
+>         cache_dir=model_args.cache_dir,
+>         revision=model_args.model_revision,
+>         use_auth_token=True if model_args.use_auth_token else None,
+>     )
+490c491
+<             pad_to_multiple_of=8 if training_args.fp16 else None,
+---
+>             pad_to_multiple_of=None,
+524c525
+<     trainer = Seq2SeqTrainer(
+---
+>     trainer = IPUSeq2SeqTrainer(
+525a527
+>         ipu_config=ipu_config,

--- a/tests/examples/run_xnli.txt
+++ b/tests/examples/run_xnli.txt
@@ -1,0 +1,28 @@
+31a32,33
+> from optimum.graphcore import IPUConfig, IPUTrainer
+> from optimum.graphcore import IPUTrainingArguments as TrainingArguments
+39,40d40
+<     Trainer,
+<     TrainingArguments,
+186,190d185
+<     # Log on each process the small summary:
+<     logger.warning(
+<         f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
+<         + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
+<     )
+244a240,245
+>     ipu_config = IPUConfig.from_pretrained(
+>         training_args.ipu_config_name if training_args.ipu_config_name else model_args.model_name_or_path,
+>         cache_dir=model_args.cache_dir,
+>         revision=model_args.model_revision,
+>         use_auth_token=True if model_args.use_auth_token else None,
+>     )
+329,330d329
+<     elif training_args.fp16:
+<         data_collator = DataCollatorWithPadding(tokenizer, pad_to_multiple_of=8)
+335c334
+<     trainer = Trainer(
+---
+>     trainer = IPUTrainer(
+336a336
+>         ipu_config=ipu_config,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -211,7 +211,7 @@ class ExampleTesterBase(TestCase):
         task_option = f"--{self.DATASET_PARAMETER_NAME} {task}" if task else " "
         ipu_config_overrides = ",".join(
             [
-                "executable_cache_dir=none",
+                "executable_cache_dir=''",
                 f"replication_factor={_ALLOWED_REPLICATION_FACTOR}",
                 f"inference_replication_factor={_ALLOWED_REPLICATION_FACTOR}",
                 "device_iterations=1",

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -299,7 +299,7 @@ class SummarizationExampleTester(ExampleTesterBase, metaclass=ExampleTestMeta, e
     ) -> List[str]:
         if extra_command_line_arguments is None:
             extra_command_line_arguments = []
-        extra_command_line_arguments.append("--dataset_config '3.0.0'")
+        extra_command_line_arguments.append("--dataset_config 3.0.0")
         extra_command_line_arguments.append("--predict_with_generate")
         if "t5" in model_name:
             extra_command_line_arguments.append("--source_prefix 'summarize: '")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -122,13 +122,13 @@ class ExampleTestMeta(type):
         @slow
         def test(self):
             if self.EXAMPLE_NAME is None:
-                raise ValueError("an example name must be provided")
+                raise ValueError("An example name must be provided")
             example_script = Path(self.EXAMPLE_DIR).glob(f"*/{self.EXAMPLE_NAME}.py")
             example_script = list(example_script)
             if len(example_script) == 0:
-                raise RuntimeError(f"could not find {self.EXAMPLE_NAME}.py in examples located in {self.EXAMPLE_DIR}")
+                raise RuntimeError(f"Could not find {self.EXAMPLE_NAME}.py in examples located in {self.EXAMPLE_DIR}")
             elif len(example_script) > 1:
-                raise RuntimeError(f"found more than {self.EXAMPLE_NAME}.py in examples located in {self.EXAMPLE_DIR}")
+                raise RuntimeError(f"Found more than {self.EXAMPLE_NAME}.py in examples located in {self.EXAMPLE_DIR}")
             else:
                 example_script = example_script[0]
 
@@ -211,7 +211,7 @@ class ExampleTesterBase(TestCase):
         task_option = f"--{self.DATASET_PARAMETER_NAME} {task}" if task else " "
         ipu_config_overrides = ",".join(
             [
-                "executable_cache_dir=''",
+                "executable_cache_dir=disabled",
                 f"replication_factor={_ALLOWED_REPLICATION_FACTOR}",
                 f"inference_replication_factor={_ALLOWED_REPLICATION_FACTOR}",
                 "device_iterations=1",

--- a/tests/test_examples_match_transformers.py
+++ b/tests/test_examples_match_transformers.py
@@ -33,6 +33,7 @@ def get_examples(
     optimum_example_dir: Union[str, PathLike],
     include_readmes: bool = False,
 ) -> List[Tuple[str]]:
+    """Retrieves the common example filenames between the transformers and  the optimum-graphcore repos."""
     glob_pattern = "*/*.py" if not include_readmes else "*/*.(py|md)"
 
     transformers_files = list(Path(transformers_example_dir).glob(glob_pattern))

--- a/tests/test_examples_match_transformers.py
+++ b/tests/test_examples_match_transformers.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2018 the HuggingFace Inc. team.
+# Copyright 2022 the HuggingFace Inc. team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,20 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import shutil
-from git import Repo
 from os import PathLike
 from pathlib import Path
 from typing import List, Tuple, Union
 
+import pytest
+from git import Repo
+
 from .create_diff_file_for_example import DIFF_DIRECTORY, diff
+
 
 TRANSFORMERS_REPO_URL = "https://github.com/huggingface/transformers.git"
 TRANSFORMERS_REPO_PATH = Path("transformers")
 
 
-def get_examples(transformers_example_dir: Union[str, PathLike], optimum_example_dir: Union[str, PathLike], include_readmes: bool = False) -> List[Tuple[str]]:
+def get_examples(
+    transformers_example_dir: Union[str, PathLike],
+    optimum_example_dir: Union[str, PathLike],
+    include_readmes: bool = False,
+) -> List[Tuple[str]]:
     glob_pattern = "*/*.py" if not include_readmes else "*/*.(py|md)"
 
     transformers_files = list(Path(transformers_example_dir).glob(glob_pattern))

--- a/tests/test_examples_match_transformers.py
+++ b/tests/test_examples_match_transformers.py
@@ -1,0 +1,70 @@
+# coding=utf-8
+# Copyright 2018 the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import shutil
+from git import Repo
+from os import PathLike
+from pathlib import Path
+from typing import List, Tuple, Union
+
+from .create_diff_file_for_example import DIFF_DIRECTORY, diff
+
+TRANSFORMERS_REPO_URL = "https://github.com/huggingface/transformers.git"
+TRANSFORMERS_REPO_PATH = Path("transformers")
+
+
+def get_examples(transformers_example_dir: Union[str, PathLike], optimum_example_dir: Union[str, PathLike], include_readmes: bool = False) -> List[Tuple[str]]:
+    glob_pattern = "*/*.py" if not include_readmes else "*/*.(py|md)"
+
+    transformers_files = list(Path(transformers_example_dir).glob(glob_pattern))
+    transformer_example_names = {p.name for p in transformers_files}
+    optimum_files = list(Path(optimum_example_dir).glob(glob_pattern))
+    optimum_example_names = {p.name for p in optimum_files}
+
+    transformer_files = sorted(p for p in transformers_files if p.name in optimum_example_names)
+    optimum_files = sorted(p for p in optimum_files if p.name in transformer_example_names)
+
+    return list(zip(transformer_files, optimum_files))
+
+
+Repo.clone_from(TRANSFORMERS_REPO_URL, TRANSFORMERS_REPO_PATH)
+EXAMPLES = get_examples(TRANSFORMERS_REPO_PATH / "examples" / "pytorch", "examples")
+
+
+@pytest.mark.parametrize("filename1,filename2", EXAMPLES, ids=lambda filename: str(filename.name))
+def test_diff_match(filename1: Path, filename2: Path):
+    reference_diff_filename = DIFF_DIRECTORY / f"{filename1.stem}.txt"
+    try:
+        with open(reference_diff_filename) as fp:
+            reference_diff = fp.read()
+    except FileNotFoundError:
+        raise FileNotFoundError(
+            f"Could not find the reference diff file for example {filename1.name}, you can create it manually or with"
+            " the command line tool located at: optimum-graphcore/tests/create_diff_file_for_example.py"
+        )
+
+    current_diff = diff(filename1, filename2)
+    assert reference_diff == current_diff
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cleanup(request):
+    # A bit hacky: this fixture will be called twice: at the beginning of the session, and at the end.
+    # The goal is to cleanup the transformers repository at the end of the test session.
+    # To do that, we first do nothing (yield some random value), which is executed at the beginning of the session, and
+    # then remove the repo, which is executed at the end of the session.
+    yield True
+    shutil.rmtree(TRANSFORMERS_REPO_PATH)

--- a/tests/test_examples_match_transformers.py
+++ b/tests/test_examples_match_transformers.py
@@ -34,7 +34,8 @@ def get_examples(
     include_readmes: bool = False,
 ) -> List[Tuple[str]]:
     """Retrieves the common example filenames between the transformers and  the optimum-graphcore repos."""
-    glob_pattern = "*/*.py" if not include_readmes else "*/*.(py|md)"
+    # TODO: validate for include README.
+    glob_pattern = "*/run_*.py" if not include_readmes else "*/(run_*|README).(py|md)"
 
     transformers_files = list(Path(transformers_example_dir).glob(glob_pattern))
     transformer_example_names = {p.name for p in transformers_files}


### PR DESCRIPTION
# What does this PR do?

It provides a test checking that the optimum version of the examples is matching the transformers one.
To do that the following is done for each example script:

1. We have a "diff" file located under `tests/examples/[name of the example script].txt`, this file acts as a reference of the differences the two files should have (Trainer vs IPUTrainer, IPUConfig stuff and so on)
2. A copy of the transformers repo is downloaded and from it the "today" difference between the transformers version and the version in optimum is computed.
3. We check that this up-to-date difference matches the reference diff file.

To create the reference diff file, a tool is provided under `tests/create_diff_file_for_example.py`:
```
python tests/create_diff_file_for_example.py \
 --transformers ~/transformers/examples/pytorch/text-classification/run_glue.py \
 --optimum examples/text-classification/run_glue.py
```

This will prompt the differences between the two files, and ask which one is "legit" interactively.