### PR TITLE
Add BERT-large config to language modelling README

### DIFF
--- a/examples/language-modeling/README.md
+++ b/examples/language-modeling/README.md
@@ -116,8 +116,8 @@ python examples/language-modeling/run_pretraining.py \
   --lamb \
   --lamb_no_bias_correction \
   --per_device_train_batch_size 8 \
-  --gradient_accumulation_steps 512 \
-  --pod_type pod64 \
+  --gradient_accumulation_steps 2048 \
+  --pod_type pod16 \
   --learning_rate 0.006 \
   --lr_scheduler_type linear \
   --loss_scaling 32768 \
@@ -146,8 +146,8 @@ python examples/language-modeling/run_pretraining.py \
   --lamb \
   --lamb_no_bias_correction \
   --per_device_train_batch_size 2 \
-  --gradient_accumulation_steps 512 \
-  --pod_type pod64 \
+  --gradient_accumulation_steps 2048 \
+  --pod_type pod16 \
   --learning_rate 0.002828 \
   --lr_scheduler_type linear \
   --loss_scaling 16384 \

--- a/examples/language-modeling/README.md
+++ b/examples/language-modeling/README.md
@@ -154,7 +154,7 @@ python examples/language-modeling/run_pretraining.py \
   --weight_decay 0.01 \
   --warmup_ratio 0.128 \
   --config_overrides "layer_norm_eps=0.001" \
-  --ipu_config_overrides "matmul_proportion=[0.15 0.2 0.2 0.2]" \
+  --ipu_config_overrides "matmul_proportion=[0.14 0.19 0.19 0.19]" \
   --output_dir output-pretrain-bert-large-phase2
 ```
 


### PR DESCRIPTION
# What does this PR do?

Updates README in [optimum-graphcore/examples/language-modeling/](https://github.com/huggingface/optimum-graphcore/tree/main/examples/language-modeling) to include BERT-large commands.

Checkpoints produced with this commands have been uploaded to [Graphcore/bert-large-uncased](https://huggingface.co/Graphcore/bert-large-uncased). The final loss after phase 2 was 1.2 and the SQuAD fine-tuning scores were EM 84.87 and F1 91.14 (reference is 84.1 and 90.9 resp. from Devlin et al. 2018)


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

