### PR TITLE
Examples sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ spell run \
   --docker_image "graphcore/pytorch:latest" \
   --apt python3 \
   --apt git \
-  "pip install git+https://github.com/huggingface/transformers.git . && \
+  "pip install . && \
    pip install -r [PATH TO POTENTIAL REQUIREMENTS] && \
    [INSERT YOUR COMMAND BETWEEN THE QUOTES]"
 ```
@@ -128,7 +128,7 @@ spell run \
   --docker_image "graphcore/pytorch:latest" \
   --apt python3 \
   --apt git \
-  "pip install git+https://github.com/huggingface/transformers.git . && \
+  "pip install . && \
    pip install -r examples/text-classification/requirements.txt && \
    python3 examples/text-classification/run_glue.py \
    --model_name_or_path bert-base-cased \

--- a/examples/image-classification/requirements.txt
+++ b/examples/image-classification/requirements.txt
@@ -1,6 +1,5 @@
+git+https://github.com/huggingface/transformers.git # Requires latest version of transformers
 --find-links https://download.pytorch.org/whl/torch_stable.html
-transformers
 datasets>=1.15.0
 torchvision==0.11.1+cpu
 scikit-learn==0.24.2
-optimum[graphcore]

--- a/examples/language-modeling/requirements.txt
+++ b/examples/language-modeling/requirements.txt
@@ -1,3 +1,4 @@
+git+https://github.com/huggingface/transformers.git # Requires latest version of transformers
 torch >= 1.3
 datasets >= 1.8.0
 sentencepiece != 0.1.92

--- a/examples/multiple-choice/requirements.txt
+++ b/examples/multiple-choice/requirements.txt
@@ -1,6 +1,5 @@
+git+https://github.com/huggingface/transformers.git # Requires latest version of transformers
 datasets
-transformers
-optimum[graphcore]
 sentencepiece != 0.1.92
 protobuf
 torch >= 1.3

--- a/examples/multiple-choice/run_swag.py
+++ b/examples/multiple-choice/run_swag.py
@@ -41,10 +41,9 @@ from transformers import (
     default_data_collator,
     set_seed,
 )
-from transformers.file_utils import PaddingStrategy
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 from transformers.trainer_utils import get_last_checkpoint
-from transformers.utils import check_min_version
+from transformers.utils import PaddingStrategy, check_min_version
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
@@ -154,7 +153,7 @@ class DataCollatorForMultipleChoice:
     Args:
         tokenizer ([`PreTrainedTokenizer`] or [`PreTrainedTokenizerFast`]):
             The tokenizer used for encoding the data.
-        padding (`bool`, `str` or [`~file_utils.PaddingStrategy`], *optional*, defaults to `True`):
+        padding (`bool`, `str` or [`~utils.PaddingStrategy`], *optional*, defaults to `True`):
             Select a strategy to pad the returned sequences (according to the model's padding side and padding index)
             among:
 
@@ -165,6 +164,7 @@ class DataCollatorForMultipleChoice:
             - `False` or `'do_not_pad'` (default): No padding (i.e., can output a batch with sequences of different
               lengths).
         max_length (`int`, *optional*):
+            Maximum length of the returned list and optionally padding length (see above).
         pad_to_multiple_of (`int`, *optional*):
             If set will pad the sequence to a multiple of the provided value.
 

--- a/examples/question-answering/requirements.txt
+++ b/examples/question-answering/requirements.txt
@@ -1,4 +1,3 @@
-transformers
+git+https://github.com/huggingface/transformers.git # Requires latest version of transformers
 datasets >= 1.8.0
-optimum[graphcore]
 torch >= 1.3.0

--- a/examples/summarization/requirements.txt
+++ b/examples/summarization/requirements.txt
@@ -1,4 +1,4 @@
-accelerate
+git+https://github.com/huggingface/transformers.git # Requires latest version of transformers
 datasets >= 1.8.0
 sentencepiece != 0.1.92
 protobuf

--- a/examples/summarization/run_summarization.py
+++ b/examples/summarization/run_summarization.py
@@ -45,9 +45,8 @@ from transformers import (
     MBartTokenizerFast,
     set_seed,
 )
-from transformers.file_utils import is_offline_mode
 from transformers.trainer_utils import get_last_checkpoint
-from transformers.utils import check_min_version
+from transformers.utils import check_min_version, is_offline_mode
 from transformers.utils.versions import require_version
 
 

--- a/examples/text-classification/requirements.txt
+++ b/examples/text-classification/requirements.txt
@@ -1,6 +1,5 @@
+git+https://github.com/huggingface/transformers.git # Requires latest version of transformers
 datasets >= 1.8.0
-transformers
-optimum[graphcore]
 sentencepiece != 0.1.92
 scipy
 scikit-learn

--- a/examples/token-classification/requirements.txt
+++ b/examples/token-classification/requirements.txt
@@ -1,5 +1,4 @@
+git+https://github.com/huggingface/transformers.git # Requires latest version of transformers
 seqeval
-transformers
 datasets >= 1.8.0
 torch >= 1.3
-optimum[graphcore]

--- a/examples/translation/requirements.txt
+++ b/examples/translation/requirements.txt
@@ -1,4 +1,4 @@
-accelerate
+git+https://github.com/huggingface/transformers.git # Requires latest version of transformers
 datasets >= 1.8.0
 sentencepiece != 0.1.92
 protobuf

--- a/tests/examples/run_summarization.txt
+++ b/tests/examples/run_summarization.txt
@@ -4,26 +4,26 @@
 44,45d45
 <     Seq2SeqTrainer,
 <     Seq2SeqTrainingArguments,
-296,300d295
+295,299d294
 <     # Log on each process the small summary:
 <     logger.warning(
 <         f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
 <         + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
 <     )
-372a368,373
+371a367,372
 >     ipu_config = IPUConfig.from_pretrained(
 >         training_args.ipu_config_name if training_args.ipu_config_name else model_args.model_name_or_path,
 >         cache_dir=model_args.cache_dir,
 >         revision=model_args.model_revision,
 >         use_auth_token=True if model_args.use_auth_token else None,
 >     )
-559c560
+558c559
 <         pad_to_multiple_of=8 if training_args.fp16 else None,
 ---
 >         pad_to_multiple_of=None,
-598c599
+597c598
 <     trainer = Seq2SeqTrainer(
 ---
 >     trainer = IPUSeq2SeqTrainer(
-599a601
+598a600
 >         ipu_config=ipu_config,

--- a/tests/examples/run_swag.txt
+++ b/tests/examples/run_swag.txt
@@ -4,39 +4,37 @@
 39,40d40
 <     Trainer,
 <     TrainingArguments,
-118c118
+117c117
 <         default=False,
 ---
 >         default=True,
-168d167
-<             Maximum length of the returned list and optionally padding length (see above).
-232,236d230
+231,235d230
 <     # Log on each process the small summary:
 <     logger.warning(
 <         f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
 <         + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
 <     )
-290a285,290
+289a285,290
 >     ipu_config = IPUConfig.from_pretrained(
 >         training_args.ipu_config_name if training_args.ipu_config_name else model_args.model_name_or_path,
 >         cache_dir=model_args.cache_dir,
 >         revision=model_args.model_revision,
 >         use_auth_token=True if model_args.use_auth_token else None,
 >     )
-383c383
+382c383
 <         else DataCollatorForMultipleChoice(tokenizer=tokenizer, pad_to_multiple_of=8 if training_args.fp16 else None)
 ---
 >         else DataCollatorForMultipleChoice(tokenizer=tokenizer, pad_to_multiple_of=None)
-385a386,391
+384a386,391
 >     if not data_args.pad_to_max_length:
 >         logging.warning(
 >             "Not padding to max length might lead to batches with difference sequence lengths, which might not work as"
 >             "expected on IPUs"
 >         )
 > 
-393c399
+392c399
 <     trainer = Trainer(
 ---
 >     trainer = IPUTrainer(
-394a401
+393a401
 >         ipu_config=ipu_config,


### PR DESCRIPTION
# What does this PR do?

This synchronizes the examples with their transformers counterparts, and adds the transformers package as a requirement to install from sources for each example.

The current issue is that optimum-graphcore requires the stable transformers package, but the examples often require installing from sources because they can us the latest changes. This was causing issues (#71), as users can end up with an "old" version of transformers when installing optimum-graphcore, making the example scripts fail.

There are multiple ways of solving this:

1. Stop checking for the latest transformers version in the examples. This can work, but since we try to match and synchronize the examples between the two libraries, it can be bug-prone.
2. Synchronizing the examples with the latest transformers release instead of the repo itself. This could work, but this is not the way they do in transformers, and it would force us to track and update the tests to make sure that they are in sync with the latest stable version.
3. Adding transformers installed from sources in the examples requirements. This is the approach taken in this PR, and it seems to be the one to make the most sense since it both follows the way it is done in transformers (the tests are guaranteed to work with transformers installed from sources), and puts the constraints on the version of transformers only in the examples, which is fair since this is the only part actually needing that.

@jimypbr @whobbes @gejinchen What do you think?

Fixes #71
