### PR TITLE
Check if loss is none in evaluation loop

### DIFF
--- a/optimum/graphcore/ipu_configuration.py
+++ b/optimum/graphcore/ipu_configuration.py
@@ -167,7 +167,7 @@ class IPUConfig(BaseConfig):
             # Optimizer state lives on- or off-chip
             .useOnChipStorage(not self.optimizer_state_offchip)
             # Shard optimizer state between replicas with zero-redundancy
-            .useReplicatedTensorSharding(self.replicated_tensor_sharding if self.replication_factor > 1 else False)
+            .useReplicatedTensorSharding(self.replicated_tensor_sharding)
         )
 
         # Use Pipelined Execution

--- a/optimum/graphcore/ipu_configuration.py
+++ b/optimum/graphcore/ipu_configuration.py
@@ -167,7 +167,7 @@ class IPUConfig(BaseConfig):
             # Optimizer state lives on- or off-chip
             .useOnChipStorage(not self.optimizer_state_offchip)
             # Shard optimizer state between replicas with zero-redundancy
-            .useReplicatedTensorSharding(self.replicated_tensor_sharding)
+            .useReplicatedTensorSharding(self.replicated_tensor_sharding if self.replication_factor > 1 else False)
         )
 
         # Use Pipelined Execution

--- a/optimum/graphcore/trainer.py
+++ b/optimum/graphcore/trainer.py
@@ -1698,7 +1698,6 @@ class IPUTrainer:
             else:
                 ignore_keys = []
 
-
         # labels may be popped when computing the loss (label smoothing for instance) so we grab them first.
         if has_labels:
             labels = nested_detach(tuple(inputs.get(name) for name in self.label_names))

--- a/optimum/graphcore/trainer.py
+++ b/optimum/graphcore/trainer.py
@@ -1589,14 +1589,13 @@ class IPUTrainer:
                 model, inputs, prediction_loss_only, ignore_keys=ignore_keys, is_last_batch=is_last_batch
             )
 
-            loss = loss.mean(dim=0, keepdim=True)
-
-            # If only one IPU is used, loss is a zero dimensional tensor, we unsqueeze to be able to concatenate.
-            if loss.dim() == 0:
-                loss = loss.unsqueeze(0)
-
             # Update containers on host
             if loss is not None:
+                loss = loss.mean(dim=0, keepdim=True)
+
+                # If only one IPU is used, loss is a zero dimensional tensor, we unsqueeze to be able to concatenate.
+                if loss.dim() == 0:
+                    loss = loss.unsqueeze(0)
                 losses_host = loss if losses_host is None else torch.cat((losses_host, loss), dim=0)
             if logits is not None:
                 preds_host = logits if preds_host is None else nested_concat(preds_host, logits, padding_index=-100)
@@ -1698,6 +1697,7 @@ class IPUTrainer:
                 ignore_keys = getattr(self.model.config, "keys_to_ignore_at_inference", [])
             else:
                 ignore_keys = []
+
 
         # labels may be popped when computing the loss (label smoothing for instance) so we grab them first.
         if has_labels:


### PR DESCRIPTION
Examples where there are no labels provided in the evalulation phase (e.g. question answering) don't output a loss. The evalulation loop in the trainer was performing operations on this loss without checking if it was None. 