### PR TITLE
Fixing the transformers version to 0.4.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Optimum Graphcore is a fast-moving project, and you may want to install from sou
 
 There are a number of examples provided in the `examples` directory. Each of these contains a README with command lines for running them on IPUs with Optimum Graphcore.
 
-**To run the examples you are required to install `optimum-graphcore` from source.** Don't forget to also install the requirements for every example:
+Please install the requirements for every example:
 
 ```
 cd <example-folder>

--- a/examples/image-classification/requirements.txt
+++ b/examples/image-classification/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/huggingface/transformers.git # Requires latest version of transformers
+transformers==4.18.0
 --find-links https://download.pytorch.org/whl/torch_stable.html
 datasets>=1.15.0
 torchvision==0.11.1+cpu

--- a/examples/image-classification/run_image_classification.py
+++ b/examples/image-classification/run_image_classification.py
@@ -55,7 +55,7 @@ from transformers.utils.versions import require_version
 logger = logging.getLogger(__name__)
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-tf_check_min_version("4.19.0.dev0")
+tf_check_min_version("4.18.0")
 
 # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 check_min_version("0.2.4.dev")

--- a/examples/language-modeling/requirements.txt
+++ b/examples/language-modeling/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/huggingface/transformers.git # Requires latest version of transformers
+transformers==4.18.0
 torch >= 1.3
 datasets >= 1.8.0
 sentencepiece != 0.1.92

--- a/examples/language-modeling/run_mlm.py
+++ b/examples/language-modeling/run_mlm.py
@@ -53,7 +53,7 @@ from transformers.utils.versions import require_version
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-tf_check_min_version("4.19.0.dev0")
+tf_check_min_version("4.18.0")
 
 # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 check_min_version("0.2.4.dev")

--- a/examples/multiple-choice/requirements.txt
+++ b/examples/multiple-choice/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/huggingface/transformers.git # Requires latest version of transformers
+transformers==4.18.0
 datasets
 sentencepiece != 0.1.92
 protobuf

--- a/examples/multiple-choice/run_swag.py
+++ b/examples/multiple-choice/run_swag.py
@@ -49,7 +49,7 @@ from transformers.utils import check_min_version as tf_check_min_version
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-tf_check_min_version("4.19.0.dev0")
+tf_check_min_version("4.18.0")
 
 # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 check_min_version("0.2.4.dev")

--- a/examples/question-answering/requirements.txt
+++ b/examples/question-answering/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/huggingface/transformers.git # Requires latest version of transformers
+transformers==4.18.0
 datasets >= 1.8.0
 torch >= 1.3.0

--- a/examples/question-answering/run_qa.py
+++ b/examples/question-answering/run_qa.py
@@ -51,7 +51,7 @@ from utils_qa import postprocess_qa_predictions
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-tf_check_min_version("4.19.0.dev0")
+tf_check_min_version("4.18.0")
 
 # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 check_min_version("0.2.4.dev")

--- a/examples/question-answering/run_vqa.py
+++ b/examples/question-answering/run_vqa.py
@@ -50,7 +50,7 @@ from transformers.utils.versions import require_version
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-tf_check_min_version("4.19.0.dev0")
+tf_check_min_version("4.18.0")
 
 # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 check_min_version("0.2.4.dev")

--- a/examples/summarization/requirements.txt
+++ b/examples/summarization/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/huggingface/transformers.git # Requires latest version of transformers
+transformers==4.18.0
 datasets >= 1.8.0
 sentencepiece != 0.1.92
 protobuf

--- a/examples/summarization/run_summarization.py
+++ b/examples/summarization/run_summarization.py
@@ -53,7 +53,7 @@ from transformers.utils.versions import require_version
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-tf_check_min_version("4.19.0.dev0")
+tf_check_min_version("4.18.0")
 
 # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 check_min_version("0.2.4.dev")

--- a/examples/text-classification/requirements.txt
+++ b/examples/text-classification/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/huggingface/transformers.git # Requires latest version of transformers
+transformers==4.18.0
 datasets >= 1.8.0
 sentencepiece != 0.1.92
 scipy

--- a/examples/text-classification/run_glue.py
+++ b/examples/text-classification/run_glue.py
@@ -48,7 +48,7 @@ from transformers.utils.versions import require_version
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-tf_check_min_version("4.19.0.dev0")
+tf_check_min_version("4.18.0")
 
 # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 check_min_version("0.2.4.dev")

--- a/examples/text-classification/run_xnli.py
+++ b/examples/text-classification/run_xnli.py
@@ -48,7 +48,7 @@ from transformers.utils.versions import require_version
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-tf_check_min_version("4.19.0.dev0")
+tf_check_min_version("4.18.0")
 
 # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 check_min_version("0.2.4.dev")

--- a/examples/token-classification/requirements.txt
+++ b/examples/token-classification/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/huggingface/transformers.git # Requires latest version of transformers
+transformers==4.18.0
 seqeval
 datasets >= 1.8.0
 torch >= 1.3

--- a/examples/token-classification/run_ner.py
+++ b/examples/token-classification/run_ner.py
@@ -49,7 +49,7 @@ from transformers.utils.versions import require_version
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-tf_check_min_version("4.19.0.dev0")
+tf_check_min_version("4.18.0")
 
 # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 check_min_version("0.2.4.dev")

--- a/examples/translation/requirements.txt
+++ b/examples/translation/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/huggingface/transformers.git # Requires latest version of transformers
+transformers==4.18.0
 datasets >= 1.8.0
 sentencepiece != 0.1.92
 protobuf

--- a/examples/translation/run_translation.py
+++ b/examples/translation/run_translation.py
@@ -52,7 +52,7 @@ from transformers.utils.versions import require_version
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-tf_check_min_version("4.19.0.dev0")
+tf_check_min_version("4.18.0")
 
 # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 check_min_version("0.2.4.dev")

--- a/tests/examples/run_glue.txt
+++ b/tests/examples/run_glue.txt
@@ -12,7 +12,7 @@
 50c51,54
 < check_min_version("4.19.0.dev0")
 ---
-> tf_check_min_version("4.19.0.dev0")
+> tf_check_min_version("4.18.0")
 > 
 > # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 > check_min_version("0.2.4.dev")

--- a/tests/examples/run_glue.txt
+++ b/tests/examples/run_glue.txt
@@ -10,7 +10,7 @@
 ---
 > from transformers.utils import check_min_version as tf_check_min_version
 50c51,54
-< check_min_version("4.19.0.dev0")
+< check_min_version("4.18.0")
 ---
 > tf_check_min_version("4.18.0")
 > 

--- a/tests/examples/run_image_classification.txt
+++ b/tests/examples/run_image_classification.txt
@@ -12,7 +12,7 @@
 57c58,61
 < check_min_version("4.19.0.dev0")
 ---
-> tf_check_min_version("4.19.0.dev0")
+> tf_check_min_version("4.18.0")
 > 
 > # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 > check_min_version("0.2.4.dev")

--- a/tests/examples/run_image_classification.txt
+++ b/tests/examples/run_image_classification.txt
@@ -10,28 +10,138 @@
 ---
 > from transformers.utils import check_min_version as tf_check_min_version
 57c58,61
-< check_min_version("4.19.0.dev0")
+< check_min_version("4.18.0")
 ---
 > tf_check_min_version("4.18.0")
 > 
 > # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 > check_min_version("0.2.4.dev")
+75,77c79,80
+<     Using `HfArgumentParser` we can turn this class
+<     into argparse arguments to be able to specify them on
+<     the command line.
+---
+>     Using `HfArgumentParser` we can turn this class into argparse arguments to be able to specify
+>     them on the command line.
+81c84,87
+<         default="nateraw/image-folder", metadata={"help": "Name of a dataset from the datasets package"}
+---
+>         default=None,
+>         metadata={
+>             "help": "Name of a dataset from the hub (could be your own, possibly private dataset hosted on the hub)."
+>         },
+107,112c113,116
+<         data_files = dict()
+<         if self.train_dir is not None:
+<             data_files["train"] = self.train_dir
+<         if self.validation_dir is not None:
+<             data_files["val"] = self.validation_dir
+<         self.data_files = data_files if data_files else None
+---
+>         if self.dataset_name is None and (self.train_dir is None and self.validation_dir is None):
+>             raise ValueError(
+>                 "You must specify either a dataset name from the hub or a train and/or validation directory."
+>             )
 181,185d184
 <     # Log on each process the small summary:
 <     logger.warning(
 <         f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
 <         + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
 <     )
-258a258,263
+204,211c203,222
+<     ds = load_dataset(
+<         data_args.dataset_name,
+<         data_args.dataset_config_name,
+<         data_files=data_args.data_files,
+<         cache_dir=model_args.cache_dir,
+<         task="image-classification",
+<         use_auth_token=True if model_args.use_auth_token else None,
+<     )
+---
+>     if data_args.dataset_name is not None:
+>         dataset = load_dataset(
+>             data_args.dataset_name,
+>             data_args.dataset_config_name,
+>             cache_dir=model_args.cache_dir,
+>             task="image-classification",
+>             use_auth_token=True if model_args.use_auth_token else None,
+>         )
+>     else:
+>         data_files = {}
+>         if data_args.train_dir is not None:
+>             data_files["train"] = os.path.join(data_args.train_dir, "**")
+>         if data_args.validation_dir is not None:
+>             data_files["validation"] = os.path.join(data_args.validation_dir, "**")
+>         dataset = load_dataset(
+>             "imagefolder",
+>             data_files=data_files,
+>             cache_dir=model_args.cache_dir,
+>             task="image-classification",
+>         )
+214c225
+<     data_args.train_val_split = None if "validation" in ds.keys() else data_args.train_val_split
+---
+>     data_args.train_val_split = None if "validation" in dataset.keys() else data_args.train_val_split
+216,218c227,229
+<         split = ds["train"].train_test_split(data_args.train_val_split)
+<         ds["train"] = split["train"]
+<         ds["validation"] = split["test"]
+---
+>         split = dataset["train"].train_test_split(data_args.train_val_split)
+>         dataset["train"] = split["train"]
+>         dataset["validation"] = split["test"]
+222c233
+<     labels = ds["train"].features["labels"].names
+---
+>     labels = dataset["train"].features["labels"].names
+246a258,263
 >     ipu_config = IPUConfig.from_pretrained(
 >         training_args.ipu_config_name if training_args.ipu_config_name else model_args.model_name_or_path,
 >         cache_dir=model_args.cache_dir,
 >         revision=model_args.model_revision,
 >         use_auth_token=True if model_args.use_auth_token else None,
 >     )
-326c331
+294c311
+<         if "train" not in ds:
+---
+>         if "train" not in dataset:
+297c314,316
+<             ds["train"] = ds["train"].shuffle(seed=training_args.seed).select(range(data_args.max_train_samples))
+---
+>             dataset["train"] = (
+>                 dataset["train"].shuffle(seed=training_args.seed).select(range(data_args.max_train_samples))
+>             )
+299c318
+<         ds["train"].set_transform(train_transforms)
+---
+>         dataset["train"].set_transform(train_transforms)
+302c321
+<         if "validation" not in ds:
+---
+>         if "validation" not in dataset:
+305,306c324,325
+<             ds["validation"] = (
+<                 ds["validation"].shuffle(seed=training_args.seed).select(range(data_args.max_eval_samples))
+---
+>             dataset["validation"] = (
+>                 dataset["validation"].shuffle(seed=training_args.seed).select(range(data_args.max_eval_samples))
+309c328
+<         ds["validation"].set_transform(val_transforms)
+---
+>         dataset["validation"].set_transform(val_transforms)
+312c331
 <     trainer = Trainer(
 ---
 >     trainer = IPUTrainer(
-327a333
+313a333
 >         ipu_config=ipu_config,
+315,316c335,336
+<         train_dataset=ds["train"] if training_args.do_train else None,
+<         eval_dataset=ds["validation"] if training_args.do_eval else None,
+---
+>         train_dataset=dataset["train"] if training_args.do_train else None,
+>         eval_dataset=dataset["validation"] if training_args.do_eval else None,
+346c366
+<         "tags": ["image-classification"],
+---
+>         "tags": ["image-classification", "vision"],

--- a/tests/examples/run_mlm.txt
+++ b/tests/examples/run_mlm.txt
@@ -12,7 +12,7 @@
 ---
 > from transformers.utils import check_min_version as tf_check_min_version
 55c56,59
-< check_min_version("4.19.0.dev0")
+< check_min_version("4.18.0")
 ---
 > tf_check_min_version("4.18.0")
 > 

--- a/tests/examples/run_mlm.txt
+++ b/tests/examples/run_mlm.txt
@@ -14,7 +14,7 @@
 55c56,59
 < check_min_version("4.19.0.dev0")
 ---
-> tf_check_min_version("4.19.0.dev0")
+> tf_check_min_version("4.18.0")
 > 
 > # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 > check_min_version("0.2.4.dev")

--- a/tests/examples/run_ner.txt
+++ b/tests/examples/run_ner.txt
@@ -10,7 +10,7 @@
 ---
 > from transformers.utils import check_min_version as tf_check_min_version
 51c52,55
-< check_min_version("4.19.0.dev0")
+< check_min_version("4.18.0")
 ---
 > tf_check_min_version("4.18.0")
 > 

--- a/tests/examples/run_ner.txt
+++ b/tests/examples/run_ner.txt
@@ -12,7 +12,7 @@
 51c52,55
 < check_min_version("4.19.0.dev0")
 ---
-> tf_check_min_version("4.19.0.dev0")
+> tf_check_min_version("4.18.0")
 > 
 > # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 > check_min_version("0.2.4.dev")

--- a/tests/examples/run_qa.txt
+++ b/tests/examples/run_qa.txt
@@ -10,7 +10,7 @@
 ---
 > from transformers.utils import check_min_version as tf_check_min_version
 51c54,57
-< check_min_version("4.19.0.dev0")
+< check_min_version("4.18.0")
 ---
 > tf_check_min_version("4.18.0")
 > 

--- a/tests/examples/run_qa.txt
+++ b/tests/examples/run_qa.txt
@@ -12,7 +12,7 @@
 51c54,57
 < check_min_version("4.19.0.dev0")
 ---
-> tf_check_min_version("4.19.0.dev0")
+> tf_check_min_version("4.18.0")
 > 
 > # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 > check_min_version("0.2.4.dev")

--- a/tests/examples/run_summarization.txt
+++ b/tests/examples/run_summarization.txt
@@ -13,7 +13,7 @@
 54c56,59
 < check_min_version("4.19.0.dev0")
 ---
-> tf_check_min_version("4.19.0.dev0")
+> tf_check_min_version("4.18.0")
 > 
 > # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 > check_min_version("0.2.4.dev")

--- a/tests/examples/run_summarization.txt
+++ b/tests/examples/run_summarization.txt
@@ -11,7 +11,7 @@
 > from transformers.utils import check_min_version as tf_check_min_version
 > from transformers.utils import is_offline_mode
 54c56,59
-< check_min_version("4.19.0.dev0")
+< check_min_version("4.18.0")
 ---
 > tf_check_min_version("4.18.0")
 > 

--- a/tests/examples/run_swag.txt
+++ b/tests/examples/run_swag.txt
@@ -11,7 +11,7 @@
 > from transformers.utils import PaddingStrategy
 > from transformers.utils import check_min_version as tf_check_min_version
 50c52,55
-< check_min_version("4.19.0.dev0")
+< check_min_version("4.18.0")
 ---
 > tf_check_min_version("4.18.0")
 > 

--- a/tests/examples/run_swag.txt
+++ b/tests/examples/run_swag.txt
@@ -13,7 +13,7 @@
 50c52,55
 < check_min_version("4.19.0.dev0")
 ---
-> tf_check_min_version("4.19.0.dev0")
+> tf_check_min_version("4.18.0")
 > 
 > # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 > check_min_version("0.2.4.dev")

--- a/tests/examples/run_translation.txt
+++ b/tests/examples/run_translation.txt
@@ -12,7 +12,7 @@
 54c55,58
 < check_min_version("4.19.0.dev0")
 ---
-> tf_check_min_version("4.19.0.dev0")
+> tf_check_min_version("4.18.0")
 > 
 > # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 > check_min_version("0.2.4.dev")

--- a/tests/examples/run_translation.txt
+++ b/tests/examples/run_translation.txt
@@ -10,7 +10,7 @@
 ---
 > from transformers.utils import check_min_version as tf_check_min_version
 54c55,58
-< check_min_version("4.19.0.dev0")
+< check_min_version("4.18.0")
 ---
 > tf_check_min_version("4.18.0")
 > 

--- a/tests/examples/run_xnli.txt
+++ b/tests/examples/run_xnli.txt
@@ -12,7 +12,7 @@
 50c51,54
 < check_min_version("4.19.0.dev0")
 ---
-> tf_check_min_version("4.19.0.dev0")
+> tf_check_min_version("4.18.0")
 > 
 > # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 > check_min_version("0.2.4.dev")

--- a/tests/examples/run_xnli.txt
+++ b/tests/examples/run_xnli.txt
@@ -10,7 +10,7 @@
 ---
 > from transformers.utils import check_min_version as tf_check_min_version
 50c51,54
-< check_min_version("4.19.0.dev0")
+< check_min_version("4.18.0")
 ---
 > tf_check_min_version("4.18.0")
 > 

--- a/tests/test_examples_match_transformers.py
+++ b/tests/test_examples_match_transformers.py
@@ -26,6 +26,7 @@ from .create_diff_file_for_example import DIFF_DIRECTORY, diff
 
 TRANSFORMERS_REPO_URL = "https://github.com/huggingface/transformers.git"
 TRANSFORMERS_REPO_PATH = Path("transformers")
+TRANSFORMERS_REPO_BRANCH = "v4.18-release"
 
 
 def get_examples(
@@ -48,7 +49,8 @@ def get_examples(
     return list(zip(transformer_files, optimum_files))
 
 
-Repo.clone_from(TRANSFORMERS_REPO_URL, TRANSFORMERS_REPO_PATH)
+repo = Repo.clone_from(TRANSFORMERS_REPO_URL, TRANSFORMERS_REPO_PATH)
+repo.git.checkout(TRANSFORMERS_REPO_BRANCH)
 EXAMPLES = get_examples(TRANSFORMERS_REPO_PATH / "examples" / "pytorch", "examples")
 
 


### PR DESCRIPTION
Main branch of transformers doesn't support Python 3.6 anymore. The examples all require source install transformers so they were broken by this. This fixes them until we can find a solution.