### PR TITLE
Fixed recomputation checkpoint to handle Tensor types

### DIFF
--- a/optimum/graphcore/modeling_utils.py
+++ b/optimum/graphcore/modeling_utils.py
@@ -194,7 +194,10 @@ def recomputation_checkpoint(module: nn.Module):
     recomputed"""
 
     def recompute_outputs(module, inputs, outputs):
-        return tuple(poptorch.recomputationCheckpoint(y) for y in outputs)
+        if isinstance(outputs, torch.Tensor):
+            return poptorch.recomputationCheckpoint(outputs)
+        elif isinstance(outputs, tuple):
+            return tuple(poptorch.recomputationCheckpoint(y) for y in outputs)
 
     return module.register_forward_hook(recompute_outputs)
 


### PR DESCRIPTION
Fixes the case when the type of `outputs` in `recomputation_checkpoint` is a `Tensor` instead of a Tuple. Needed for the convnet models.
