### PR TITLE
Reload rng_state when checkpointing

### DIFF
--- a/optimum/graphcore/trainer.py
+++ b/optimum/graphcore/trainer.py
@@ -1327,9 +1327,11 @@ class IPUTrainer:
                 state_dict = self.model.state_dict()
             torch.save(state_dict, os.path.join(output_dir, WEIGHTS_NAME))
         else:
+            rng_state = torch.random.get_rng_state()
             self.model.deparallelize()
             self.model.save_pretrained(output_dir, state_dict=state_dict)
             self.model.parallelize()
+            torch.random.set_rng_state(rng_state)
 
         if self.tokenizer is not None:
             self.tokenizer.save_pretrained(output_dir)


### PR DESCRIPTION
While saving the checkpoint, get the random number generator state before `deparallelize()` and reload it after `parallelize()`, so that checkpointing won't alter the random state and we could have reproducibility no matter what the frequency of checkpointing is.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

