### PR TITLE
Fix num samples for speed metrics

### DIFF
--- a/optimum/graphcore/trainer.py
+++ b/optimum/graphcore/trainer.py
@@ -832,7 +832,6 @@ class IPUTrainer:
         total_train_batch_size = args.per_device_train_batch_size * self.ipu_config.batch_size_factor()
         if train_dataset_is_sized:
             # No need to divide by the number of gradient accumulation steps as poptorch already accounts for that.
-            # num_update_steps_per_epoch = len(train_dataloader) // args.gradient_accumulation_steps
             num_update_steps_per_epoch = len(train_dataloader)
             num_update_steps_per_epoch = max(num_update_steps_per_epoch, 1)
             if args.max_steps > 0:
@@ -840,14 +839,12 @@ class IPUTrainer:
                 num_train_epochs = args.max_steps // num_update_steps_per_epoch + int(
                     args.max_steps % num_update_steps_per_epoch > 0
                 )
-
-                # May be slightly incorrect if the last batch in the training datalaoder has a smaller size but it's
-                # the best we can do.
-                num_train_samples = args.max_steps * total_train_batch_size
             else:
                 max_steps = math.ceil(args.num_train_epochs * num_update_steps_per_epoch)
                 num_train_epochs = math.ceil(args.num_train_epochs)
-                num_train_samples = len(self.train_dataset) * args.num_train_epochs
+            # May be slightly incorrect if the last batch in the training dataloader has a smaller size but it's
+            # the best we can do.
+            num_train_samples = max_steps * total_train_batch_size
         else:
             # see __init__. max_steps is set when the dataset has no __len__
             max_steps = args.max_steps

--- a/optimum/graphcore/trainer.py
+++ b/optimum/graphcore/trainer.py
@@ -1650,14 +1650,7 @@ class IPUTrainer:
             all_labels = labels if all_labels is None else nested_concat(all_labels, labels, padding_index=-100)
 
         # Number of samples
-        if not isinstance(eval_dataset, IterableDataset):
-            num_samples = len(eval_dataset)
-        # The instance check is weird and does not actually check for the type, but whether the dataset has the right
-        # methods. Therefore we need to make sure it also has the attribute.
-        elif isinstance(eval_dataset, IterableDatasetShard) and hasattr(eval_dataset, "num_examples"):
-            num_samples = eval_dataset.num_examples
-        else:
-            num_samples = observed_num_examples
+        num_samples = observed_num_examples
 
         # Number of losses has been rounded to a multiple of batch_size and in a distributed training, the number of
         # samplers has been rounded to a multiple of batch_size, so we truncate.


### PR DESCRIPTION
# What does this PR do?

- Fixes the way speed metrics are computed for the training loop, before the number of samples was computed as follows:
```
num_samples = number of examples in the dataset x number of epochs
```

But this can over-evaluate the speed metric if the last batch is being dropped, and the batch size very big. Instead, we do now:
```
num_samples = math.ceil(args.num_train_epochs * num_update_steps_per_epoch) x total_train_batch_size
```

This might under-evaluate the speed if the last batch is mostly empty, but solves our issue of over-evaluating when dropping the last batch.

For evaluation / prediction, we always use the number of examples actually seen as the number of samples, not sure why it was not the case in the original Trainer.