### PR TITLE
Fix models for dispatch tracing

### DIFF
--- a/examples/multiple-choice/README.md
+++ b/examples/multiple-choice/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 `run_swag` allows you to fine-tune any model from our [hub](https://huggingface.co/models) (as long as its architecture as a `ForMultipleChoice` version in the library) on the SWAG dataset or your own csv/jsonlines files as long as they are structured the same way. To make it works on another dataset, you will need to tweak the `preprocess_function` inside the script.
 
-```bash
+```
 python examples/multiple-choice/run_swag.py \
 --model_name_or_path roberta-base \
 --ipu_config_name Graphcore/roberta-base-ipu \
@@ -29,17 +29,18 @@ python examples/multiple-choice/run_swag.py \
 --learning_rate 5e-5 \
 --num_train_epochs 3 \
 --output_dir ./output/swag_base \
---per_device_eval_batch_size=16 \
---per_device_train_batch_size=16 \
+--per_device_eval_batch_size=2 \
+--per_device_train_batch_size=2 \
+--gradient_accumulation_steps 16 \
 --pod_type pod16 \
+--report_to none \
+--pad_on_batch_axis \
 --overwrite_output
 ```
 
-<!-- TODO: compute metrics
 Training with the defined hyper-parameters yields the following results:
 ```
 ***** Eval results *****
-eval_acc = 0.8338998300509847
-eval_loss = 0.44457291918821606
+eval_acc = 0.8396
+eval_loss = 0.439
 ```
--->

--- a/optimum/graphcore/ipu_configuration.py
+++ b/optimum/graphcore/ipu_configuration.py
@@ -215,6 +215,8 @@ class IPUConfig(BaseConfig):
         if self.enable_half_partials:
             opts.Precision.setPartialsType(torch.float16)
 
+        opts.Jit.traceModel(False)
+
         # PopART performance options #
         # Replaces single sums of partial gradients with a tree of additions
         opts._Popart.set("decomposeGradSum", self.decompose_grad_sum)

--- a/optimum/graphcore/modeling_utils.py
+++ b/optimum/graphcore/modeling_utils.py
@@ -335,7 +335,7 @@ class SerializedLinear(nn.Linear):
         else:
             output = poptorch.serializedMatMul(x, self.weight.t(), self.mode, self.factor)
             if self.bias is not None:
-                output += self.bias
+                output = output + self.bias
         return output
 
 
@@ -389,27 +389,10 @@ class OnehotGather(nn.Module):
     into a one-hot matrix and then multiplying the tensor by that matrix.
     """
 
-    def __init__(self):
-        super().__init__()
-        self._is_half = False
-
-    def half(self):
-        super().half()
-        # Tracing is always executed in float as there are missing
-        # implementations of operations in half on the CPU.
-        # So we cannot query the inputs to know if we are running
-        # with a model that has had .half() called on it.
-        # To work around it nn.Module::half is overridden
-        self._is_half = True
-
     def forward(self, sequence, positions):
         """
         Gather the vectors at the specific positions over a batch.
         """
         num_classes = int(sequence.shape[1])
-        one_hot_positions = F.one_hot(positions, num_classes)
-        if self._is_half:
-            one_hot_positions = one_hot_positions.half()
-        else:
-            one_hot_positions = one_hot_positions.float()
+        one_hot_positions = F.one_hot(positions, num_classes).to(dtype=sequence.dtype)
         return torch.matmul(one_hot_positions.detach(), sequence)

--- a/optimum/graphcore/models/bert/modeling_bert.py
+++ b/optimum/graphcore/models/bert/modeling_bert.py
@@ -28,6 +28,7 @@ from transformers import (
     BertForTokenClassification,
 )
 from transformers.models.bert.modeling_bert import BertSelfAttention
+from transformers.modeling_outputs import QuestionAnsweringModelOutput
 
 from ...modeling_utils import (
     OnehotGather,
@@ -40,6 +41,8 @@ from ...modeling_utils import (
     register,
 )
 from .bert_fused_attention import BertFusedSelfAttention
+
+from typing import Optional, Tuple, Union
 
 
 logger = logging.get_logger(__name__)
@@ -383,15 +386,6 @@ class PipelinedBertForSequenceClassification(BertForSequenceClassification, Bert
         logger.info("-----------------------------------------------------------")
         return self
 
-    def forward(self, input_ids, attention_mask, token_type_ids, labels=None):
-        return super().forward(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-            token_type_ids=token_type_ids,
-            labels=labels,
-            return_dict=False,
-        )
-
 
 @register(BertForMultipleChoice)
 class PipelinedBertForMultipleChoice(BertForMultipleChoice, BertPipelineMixin):
@@ -411,15 +405,6 @@ class PipelinedBertForMultipleChoice(BertForMultipleChoice, BertPipelineMixin):
         self.classifier = poptorch.BeginBlock(self.classifier, "Classifier Output", ipu_id=last_ipu)
         logger.info("-----------------------------------------------------------")
         return self
-
-    def forward(self, input_ids, attention_mask, token_type_ids, labels=None):
-        return super().forward(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-            token_type_ids=token_type_ids,
-            labels=labels,
-            return_dict=False,
-        )
 
 
 @register(BertForTokenClassification)
@@ -441,15 +426,6 @@ class PipelinedBertForTokenClassification(BertForTokenClassification, BertPipeli
         logger.info("-----------------------------------------------------------")
         return self
 
-    def forward(self, input_ids, attention_mask, token_type_ids, labels=None):
-        return super().forward(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-            token_type_ids=token_type_ids,
-            labels=labels,
-            return_dict=False,
-        )
-
 
 @register(BertForQuestionAnswering)
 class PipelinedBertForQuestionAnswering(BertForQuestionAnswering, BertPipelineMixin):
@@ -470,15 +446,46 @@ class PipelinedBertForQuestionAnswering(BertForQuestionAnswering, BertPipelineMi
         logger.info("-----------------------------------------------------------")
         return self
 
-    def forward(self, input_ids, attention_mask, token_type_ids, start_positions=None, end_positions=None):
+    def forward(
+        self,
+        input_ids: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        token_type_ids: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+        head_mask: Optional[torch.Tensor] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        start_positions: Optional[torch.Tensor] = None,
+        end_positions: Optional[torch.Tensor] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+    ) -> Union[Tuple[torch.Tensor], QuestionAnsweringModelOutput]:
+        r"""
+        start_positions (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
+            Labels for position (index) of the start of the labelled span for computing the token classification loss.
+            Positions are clamped to the length of the sequence (`sequence_length`). Position outside of the sequence
+            are not taken into account for computing the loss.
+        end_positions (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
+            Labels for position (index) of the end of the labelled span for computing the token classification loss.
+            Positions are clamped to the length of the sequence (`sequence_length`). Position outside of the sequence
+            are not taken into account for computing the loss.
+        """
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
         output = super().forward(
-            input_ids=input_ids,
+            input_ids,
             attention_mask=attention_mask,
             token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
             start_positions=start_positions,
             end_positions=end_positions,
-            return_dict=False,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
         )
+
         if start_positions is not None and end_positions is not None:
             output = (poptorch.identity_loss(output[0], reduction="none"),) + output[1:]
         return output

--- a/optimum/graphcore/models/convnext/modeling_convnext.py
+++ b/optimum/graphcore/models/convnext/modeling_convnext.py
@@ -103,6 +103,3 @@ class PipelinedConvNextForImageClassification(transformers.ConvNextForImageClass
         for stage in self.convnext.encoder.stages:
             for layer in stage.layers:
                 layer.__class__ = ConvNextLayer
-
-    def forward(self, pixel_values=None, labels=None):
-        return super().forward(pixel_values=pixel_values, labels=labels, return_dict=False)

--- a/optimum/graphcore/models/deberta/__init__.py
+++ b/optimum/graphcore/models/deberta/__init__.py
@@ -20,4 +20,5 @@ from .modeling_deberta import (
     PipelinedDebertaForQuestionAnswering,
     PipelinedDebertaForSequenceClassification,
     PipelinedDebertaForTokenClassification,
+    PipelinedDebertaForMaskedLM,
 )

--- a/optimum/graphcore/models/gpt2/modeling_gpt2.py
+++ b/optimum/graphcore/models/gpt2/modeling_gpt2.py
@@ -261,11 +261,3 @@ class PipelinedGPT2ForTokenClassification(GPT2ForTokenClassification, GPT2Pipeli
         self.classifier = poptorch.BeginBlock(self.classifier, "Classifier", ipu_id=last_ipu)
         logger.info("-----------------------------------------------------------")
         return self
-
-    def forward(self, input_ids, attention_mask, labels=None):
-        return super().forward(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-            labels=labels,
-            return_dict=False,
-        )

--- a/optimum/graphcore/models/hubert/modeling_hubert.py
+++ b/optimum/graphcore/models/hubert/modeling_hubert.py
@@ -67,21 +67,3 @@ class PipelinedHubertForSequenceClassification(HubertForSequenceClassification, 
         super().deparallelize()
         self.change_hubert_encoder_class(True)
         return self
-
-    @poptorch.autocast(enabled=True)
-    def forward(
-        self,
-        input_values,
-        labels=None,
-        attention_mask=None,
-        output_attentions=None,
-        output_hidden_states=None,
-    ):
-        return super().forward(
-            input_values,
-            attention_mask=attention_mask,
-            output_attentions=False,
-            output_hidden_states=False,
-            return_dict=False,
-            labels=labels,
-        )

--- a/optimum/graphcore/models/roberta/modeling_roberta.py
+++ b/optimum/graphcore/models/roberta/modeling_roberta.py
@@ -25,6 +25,7 @@ from transformers import (
     RobertaForSequenceClassification,
     RobertaForTokenClassification,
 )
+from transformers.modeling_outputs import QuestionAnsweringModelOutput
 
 from ...modeling_utils import (
     OnehotGather,
@@ -36,6 +37,8 @@ from ...modeling_utils import (
     recomputation_checkpoint,
     register,
 )
+
+from typing import Optional, Tuple, Union
 
 
 logger = logging.get_logger(__name__)
@@ -201,14 +204,6 @@ class PipelinedRobertaForSequenceClassification(RobertaForSequenceClassification
         logger.info("-----------------------------------------------------------")
         return self
 
-    def forward(self, input_ids, attention_mask, labels=None):
-        return super().forward(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-            labels=labels,
-            return_dict=False,
-        )
-
 
 @register(RobertaForMultipleChoice)
 class PipelinedRobertaForMultipleChoice(RobertaForMultipleChoice, RobertaPipelineMixin):
@@ -228,14 +223,6 @@ class PipelinedRobertaForMultipleChoice(RobertaForMultipleChoice, RobertaPipelin
         self.classifier = poptorch.BeginBlock(self.classifier, "Classifier Output", ipu_id=last_ipu)
         logger.info("-----------------------------------------------------------")
         return self
-
-    def forward(self, input_ids, attention_mask, labels=None):
-        return super().forward(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-            labels=labels,
-            return_dict=False,
-        )
 
 
 @register(RobertaForTokenClassification)
@@ -257,14 +244,6 @@ class PipelinedRobertaForTokenClassification(RobertaForTokenClassification, Robe
         logger.info("-----------------------------------------------------------")
         return self
 
-    def forward(self, input_ids, attention_mask, labels=None):
-        return super().forward(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-            labels=labels,
-            return_dict=False,
-        )
-
 
 @register(RobertaForQuestionAnswering)
 class PipelinedRobertaForQuestionAnswering(RobertaForQuestionAnswering, RobertaPipelineMixin):
@@ -285,13 +264,44 @@ class PipelinedRobertaForQuestionAnswering(RobertaForQuestionAnswering, RobertaP
         logger.info("-----------------------------------------------------------")
         return self
 
-    def forward(self, input_ids, attention_mask, start_positions=None, end_positions=None):
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.FloatTensor] = None,
+        token_type_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        start_positions: Optional[torch.LongTensor] = None,
+        end_positions: Optional[torch.LongTensor] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+    ) -> Union[Tuple[torch.Tensor], QuestionAnsweringModelOutput]:
+        r"""
+        start_positions (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
+            Labels for position (index) of the start of the labelled span for computing the token classification loss.
+            Positions are clamped to the length of the sequence (`sequence_length`). Position outside of the sequence
+            are not taken into account for computing the loss.
+        end_positions (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
+            Labels for position (index) of the end of the labelled span for computing the token classification loss.
+            Positions are clamped to the length of the sequence (`sequence_length`). Position outside of the sequence
+            are not taken into account for computing the loss.
+        """
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
         output = super().forward(
-            input_ids=input_ids,
+            input_ids,
             attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
             start_positions=start_positions,
             end_positions=end_positions,
-            return_dict=False,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
         )
         if start_positions is not None and end_positions is not None:
             output = (poptorch.identity_loss(output[0], reduction="none"),) + output[1:]

--- a/optimum/graphcore/models/vit/modeling_vit.py
+++ b/optimum/graphcore/models/vit/modeling_vit.py
@@ -46,6 +46,3 @@ class PipelinedViTForImageClassification(transformers.ViTForImageClassification,
         self.vit.layernorm = poptorch.BeginBlock(self.vit.layernorm, "LayerNorm", ipu_id=last_ipu)
         self.classifier = poptorch.BeginBlock(self.classifier, "Classifier", ipu_id=last_ipu)
         return self
-
-    def forward(self, pixel_values, labels=None):
-        return super().forward(pixel_values=pixel_values, labels=labels, return_dict=False)

--- a/tests/examples/run_glue.txt
+++ b/tests/examples/run_glue.txt
@@ -1,47 +1,59 @@
-30a31,33
+29a30
+> import torch
+30a32,34
 > from optimum.graphcore import IPUConfig, IPUTrainer
 > from optimum.graphcore import IPUTrainingArguments as TrainingArguments
 > from optimum.graphcore.utils import check_min_version
-39,40d41
+39,40d42
 <     Trainer,
 <     TrainingArguments,
-45c46,47
+45c47,48
 < from transformers.utils import check_min_version, send_example_telemetry
 ---
 > from transformers.utils import check_min_version as tf_check_min_version
 > from transformers.utils import send_example_telemetry
-50c52,55
+50c53,56
 < check_min_version("4.20.0")
 ---
 > tf_check_min_version("4.20.0")
 > 
 > # Will error if the minimal version of Optimum Graphcore is not installed. Remove at your own risks.
 > check_min_version("0.2.4.dev0")
-236,240d240
+236,240d241
 <     # Log on each process the small summary:
 <     logger.warning(
 <         f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
 <         + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
 <     )
-360a361,366
+360a362,367
 >     ipu_config = IPUConfig.from_pretrained(
 >         training_args.ipu_config_name if training_args.ipu_config_name else model_args.model_name_or_path,
 >         cache_dir=model_args.cache_dir,
 >         revision=model_args.model_revision,
 >         use_auth_token=True if model_args.use_auth_token else None,
 >     )
-377a384,388
+377a385,389
 >     # Customize tokenization for GPT2. We reuse the EOS token as the PAD token.
 >     if config.model_type == "gpt2":
 >         tokenizer.pad_token = tokenizer.eos_token
 >         model.config.pad_token_id = model.config.eos_token_id
 > 
-506,507d516
+459a472,480
+>         labels = torch.tensor(train_dataset[0]["label"])
+>         if model.config.problem_type is None:
+>             if model.config.num_labels == 1:
+>                 model.config.problem_type = "regression"
+>             elif model.config.num_labels > 1 and (labels.dtype == torch.long or labels.dtype == torch.int):
+>                 model.config.problem_type = "single_label_classification"
+>             else:
+>                 model.config.problem_type = "multi_label_classification"
+> 
+506,507d526
 <     elif training_args.fp16:
 <         data_collator = DataCollatorWithPadding(tokenizer, pad_to_multiple_of=8)
-512c521
+512c531
 <     trainer = Trainer(
 ---
 >     trainer = IPUTrainer(
-513a523
+513a533
 >         ipu_config=ipu_config,


### PR DESCRIPTION
# What does this PR do?

This enables the new dispatch tracing, which was previewed in SDK2.6 and will be supported in the next SDK.
Dispatch tracing will allow the following:
* Fixes the positional argument constraint to the models that needed to be worked-around. Can now use the exact same arguments as HF, including passing kwargs
* Can pass dictionaries and return dictionaries to poptorch model runners.
* All cases of mixed precision now work correctly. It also removes the `poptorch.autocast` feature.
* Tracing is much faster than before.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

