### PR TITLE
Make test examples tests use individual venvs

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -205,6 +205,12 @@ class ExampleTesterBase(TestCase):
     TRAIN_REPLICATION_FACTOR = 2
     INFERENCE_REPLICATION_FACTOR = 2
 
+    def setUp(self):
+        self._create_venv()
+
+    def tearDown(self):
+        return self._remove_venv()
+
     def _create_command_line(
         self,
         script: str,
@@ -260,13 +266,50 @@ class ExampleTesterBase(TestCase):
         pattern = re.compile(r"([\"\'].+?[\"\'])|\s")
         return [x for y in cmd_line for x in re.split(pattern, y) if x]
 
+    def _create_venv(self):
+        """
+        Creates the virtual environment for the example.
+        """
+        cmd_line = "python -m venv venv".split()
+        p = subprocess.Popen(cmd_line)
+        return_code = p.wait()
+        self.assertEqual(return_code, 0)
+        self.venv_was_created = True
+
+    def _remove_venv(self):
+        """
+        Creates the virtual environment for the example.
+        """
+        if self.venv_was_created:
+            cmd_line = "rm -rf venv".split()
+            p = subprocess.Popen(cmd_line)
+            return_code = p.wait()
+            self.assertEqual(return_code, 0)
+            self.venv_was_created = False
+
     def _install_requirements(self, requirements_filename: Union[str, os.PathLike]):
         """
         Installs the necessary requirements to run the example if the provided file exists, otherwise does nothing.
         """
+        pip_name = "venv/bin/pip" if self.venv_was_created else "pip"
+
+        # Update pip
+        cmd_line = f"{pip_name} install --upgrade pip".split()
+        p = subprocess.Popen(cmd_line)
+        return_code = p.wait()
+        self.assertEqual(return_code, 0)
+
+        # Install SDK
+        sdk_path = os.environ["SDK_PATH"]
+        cmd_line = f"{pip_name} install .[testing] {sdk_path}/poptorch-*.whl"
+        p = subprocess.Popen(cmd_line, shell=True)
+        return_code = p.wait()
+        self.assertEqual(return_code, 0)
+
+        # Install requirements
         if not Path(requirements_filename).exists():
             return
-        cmd_line = f"pip install -r {requirements_filename}".split()
+        cmd_line = f"{pip_name} install -r {requirements_filename}".split()
         p = subprocess.Popen(cmd_line)
         return_code = p.wait()
         self.assertEqual(return_code, 0)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -300,7 +300,7 @@ class ExampleTesterBase(TestCase):
         self.assertEqual(return_code, 0)
 
         # Install SDK
-        sdk_path = os.environ["SDK_PATH"]
+        sdk_path = os.environ.get("SDK_PATH", Path(os.environ.get("POPLAR_SDK_ENABLED")).parent)
         cmd_line = f"{pip_name} install .[testing] {sdk_path}/poptorch-*.whl"
         p = subprocess.Popen(cmd_line, shell=True)
         return_code = p.wait()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -241,6 +241,7 @@ class ExampleTesterBase(TestCase):
         )
 
         cmd_line = [
+            "venv_tmp/bin/python" if self.venv_was_created else "python",
             f"{script}",
             f"--model_name_or_path {model_name}",
             f"--ipu_config_name {ipu_config_name}",
@@ -270,7 +271,7 @@ class ExampleTesterBase(TestCase):
         """
         Creates the virtual environment for the example.
         """
-        cmd_line = "python -m venv venv".split()
+        cmd_line = "python -m venv venv_tmp".split()
         p = subprocess.Popen(cmd_line)
         return_code = p.wait()
         self.assertEqual(return_code, 0)
@@ -281,7 +282,7 @@ class ExampleTesterBase(TestCase):
         Creates the virtual environment for the example.
         """
         if self.venv_was_created:
-            cmd_line = "rm -rf venv".split()
+            cmd_line = "rm -rf venv_tmp".split()
             p = subprocess.Popen(cmd_line)
             return_code = p.wait()
             self.assertEqual(return_code, 0)
@@ -291,7 +292,7 @@ class ExampleTesterBase(TestCase):
         """
         Installs the necessary requirements to run the example if the provided file exists, otherwise does nothing.
         """
-        pip_name = "venv/bin/pip" if self.venv_was_created else "pip"
+        pip_name = "venv_tmp/bin/pip" if self.venv_was_created else "pip"
 
         # Update pip
         cmd_line = f"{pip_name} install --upgrade pip".split()
@@ -310,15 +311,6 @@ class ExampleTesterBase(TestCase):
         if not Path(requirements_filename).exists():
             return
         cmd_line = f"{pip_name} install -r {requirements_filename}".split()
-        p = subprocess.Popen(cmd_line)
-        return_code = p.wait()
-        self.assertEqual(return_code, 0)
-
-    def _cleanup_dataset_cache(self):
-        """
-        Cleans up the dataset cache to free up space for other tests.
-        """
-        cmd_line = ["rm" "-r", "/nethome/michaelb/.cache/huggingface/datasets"]
         p = subprocess.Popen(cmd_line)
         return_code = p.wait()
         self.assertEqual(return_code, 0)


### PR DESCRIPTION
# What does this PR do?

Runs examples from text_examples.py in their own virtualenvs. 
This should fix the nfs issue we are seeing with the test_examples CI when installing the requirements.

Adapted from https://github.com/huggingface/optimum-graphcore/pull/174

