### PR TITLE
Modify LAMB to disable LAMB updates on bias parameters

### DIFF
--- a/optimum/graphcore/trainer.py
+++ b/optimum/graphcore/trainer.py
@@ -684,9 +684,9 @@ class IPUTrainer:
         """
         if self.optimizer is None:
             decay_parameters = get_parameter_names(self.model, [nn.LayerNorm])
-            decay_parameters = [name for name in decay_parameters if "bias" not in name]
+            decay_parameters = {name for name in decay_parameters if "bias" not in name}
             if self.args.lamb or self.args.lamb_no_bias_correction:
-                bias_parameters = [n for n, _ in self.model.named_parameters() if "bias" in n]
+                bias_parameters = {n for n, _ in self.model.named_parameters() if "bias" in n}
                 optimizer_grouped_parameters = [
                     {
                         "params": [p for n, p in self.model.named_parameters() if n in decay_parameters],

--- a/optimum/graphcore/trainer.py
+++ b/optimum/graphcore/trainer.py
@@ -684,6 +684,7 @@ class IPUTrainer:
         """
         if self.optimizer is None:
             decay_parameters = get_parameter_names(self.model, [nn.LayerNorm])
+            bias_parameters = [name for name in decay_parameters if "bias" in name]
             decay_parameters = [name for name in decay_parameters if "bias" not in name]
             optimizer_grouped_parameters = [
                 {
@@ -691,8 +692,14 @@ class IPUTrainer:
                     "weight_decay": self.args.weight_decay,
                 },
                 {
-                    "params": [p for n, p in self.model.named_parameters() if n not in decay_parameters],
+                    "params": [p for n, p in self.model.named_parameters() if n not in decay_parameters and n not in bias_parameters],
                     "weight_decay": 0.0,
+                },
+                {
+                    # Disable LAMB updates for bias parameters
+                    "params": [p for n, p in self.model.named_parameters() if n in bias_parameters],
+                    "weight_decay": 0.0,
+                    "max_weight_norm": 0.0,
                 },
             ]
             if self.args.lamb or self.args.lamb_no_bias_correction:

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1184,8 +1184,6 @@ class IPUTrainerIntegrationTest(TestCasePlus, IPUTrainerIntegrationCommon):
         ipu_config = get_ipu_config()
         args = IPUTrainingArguments(".", fp32=True)
         trainer = IPUTrainer(model=model, ipu_config=ipu_config, args=args, force_to_pipelined=True)
-        # from transformers import Trainer
-        # trainer = Trainer(model=model)
         trainer.create_optimizer_and_scheduler(10)
         # fmt: off
         wd_names = ['0.linear1.weight', '0.linear2.weight', '1.0.linear1.weight', '1.0.linear2.weight', '1.1.linear1.weight', '1.1.linear2.weight']
@@ -1208,18 +1206,13 @@ class IPUTrainerIntegrationTest(TestCasePlus, IPUTrainerIntegrationCommon):
         ipu_config = get_ipu_config()
         args = IPUTrainingArguments(".", fp32=True, lamb=True)
         trainer = IPUTrainer(model=model, ipu_config=ipu_config, args=args, force_to_pipelined=True)
-        # from transformers import Trainer
-        # trainer = Trainer(model=model)
         trainer.create_optimizer_and_scheduler(10)
         # fmt: off
-        # print([n for n, p in model.named_parameters()])
-        names = ['0.linear1.weight',  '0.linear2.weight', '1.0.linear1.weight', '1.0.linear2.weight', '1.1.linear1.weight', '1.1.linear2.weight']
         wd_names = ['0.linear1.weight', '0.linear2.weight', '1.0.linear1.weight', '1.0.linear2.weight', '1.1.linear1.weight', '1.1.linear2.weight']
         bias_names = ['0.bias', '0.linear1.bias', '0.ln1.bias', '0.linear2.bias', '0.ln2.bias', '1.0.bias', '1.0.linear1.bias', '1.0.ln1.bias',
                       '1.0.linear2.bias', '1.0.ln2.bias', '1.1.bias', '1.1.linear1.bias', '1.1.ln1.bias', '1.1.linear2.bias', '1.1.ln2.bias']
         other_names = ['0.ln1.weight', '0.ln2.weight', '1.0.ln1.weight', '1.0.ln2.weight', '1.1.ln1.weight', '1.1.ln2.weight']
 
-        # fmt: on
         wd_params = [p for n, p in model.named_parameters() if n in wd_names]
         no_lamb_update_params = [p for n, p in model.named_parameters() if n in bias_names]
         other_params = [p for n, p in model.named_parameters() if n in other_names]

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1212,6 +1212,7 @@ class IPUTrainerIntegrationTest(TestCasePlus, IPUTrainerIntegrationCommon):
         bias_names = ['0.bias', '0.linear1.bias', '0.ln1.bias', '0.linear2.bias', '0.ln2.bias', '1.0.bias', '1.0.linear1.bias', '1.0.ln1.bias',
                       '1.0.linear2.bias', '1.0.ln2.bias', '1.1.bias', '1.1.linear1.bias', '1.1.ln1.bias', '1.1.linear2.bias', '1.1.ln2.bias']
         other_names = ['0.ln1.weight', '0.ln2.weight', '1.0.ln1.weight', '1.0.ln2.weight', '1.1.ln1.weight', '1.1.ln2.weight']
+        # fmt: on
 
         wd_params = [p for n, p in model.named_parameters() if n in wd_names]
         no_lamb_update_params = [p for n, p in model.named_parameters() if n in bias_names]


### PR DESCRIPTION
# What does this PR do?

Disabled the LAMB update of bias parameters in the model. Bias parameters will be instead updated with AdamW. We've found experimentally that this helps mitigate underflow of bias variables in training. This improves stability of BERT pretraining.