### PR TITLE
Use correct package name for scikit-learn in requirements

### DIFF
--- a/examples/audio-classification/requirements.txt
+++ b/examples/audio-classification/requirements.txt
@@ -2,4 +2,4 @@
 datasets>=1.14.0
 librosa
 torchaudio==0.10.0+cpu
-sklearn
+scikit-learn


### PR DESCRIPTION
# What does this PR do?

It uses `scikit-learn` rather than `sklearn` in a `requirements.txt` file.

scikit-learn is the actual package name, using `sklearn` in requirement files will stop working December 1st 2022. For more details, see https://github.com/scikit-learn/sklearn-pypi-package.

## Before submitting

I checked the small issue box since it seems to apply best.

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

