### PR TITLE
Remove deprecated and unused autocast IPU option 

### DIFF
--- a/optimum/graphcore/ipu_configuration.py
+++ b/optimum/graphcore/ipu_configuration.py
@@ -220,15 +220,8 @@ class IPUConfig(BaseConfig):
             raise NotImplementedError("execute_encoder_on_cpu_for_generation is not supported yet.")
 
         opts = Options()
-
-        # Define a policy to make sure LayerNorm related ops are computed in fp32
-        fp32 = [torch.mean, torch.rsqrt, torch.pow, torch.add]
-        policy = poptorch.autocasting.Policy([], fp32, [], [])
-        opts.Precision.autocastPolicy(policy)
-
-        opts.replicationFactor(self.inference_replication_factor if for_inference else self.replication_factor)
-
         opts.autoRoundNumIPUs(True)
+        opts.replicationFactor(self.inference_replication_factor if for_inference else self.replication_factor)
         opts.deviceIterations(self.inference_device_iterations if for_inference else self.device_iterations)
 
         if not for_inference:

--- a/optimum/graphcore/models/convnext/modeling_convnext.py
+++ b/optimum/graphcore/models/convnext/modeling_convnext.py
@@ -70,7 +70,7 @@ class PipelinedConvNextForImageClassification(ConvNextForImageClassification, Pi
             for layer in stage.layers:
                 layer.__class__ = OptimizedConvNextLayer
 
-        # ConvNextLayerNorm does not correctly handle fp16. 
+        # ConvNextLayerNorm does not correctly handle fp16.
         # TODO remove this in newer version of transformers that has https://github.com/huggingface/transformers/pull/18746
         for mod in self.modules():
             if isinstance(mod, ConvNextLayerNorm):

--- a/optimum/graphcore/models/convnext/modeling_convnext.py
+++ b/optimum/graphcore/models/convnext/modeling_convnext.py
@@ -70,7 +70,8 @@ class PipelinedConvNextForImageClassification(ConvNextForImageClassification, Pi
             for layer in stage.layers:
                 layer.__class__ = OptimizedConvNextLayer
 
-        # Enable autocast for ConvNextLayerNorm because computation cannot happen in fp16
+        # ConvNextLayerNorm does not correctly handle fp16. 
+        # TODO remove this in newer version of transformers that has https://github.com/huggingface/transformers/pull/18746
         for mod in self.modules():
             if isinstance(mod, ConvNextLayerNorm):
                 mod.__class__ = IPUConvNextLayerNorm


### PR DESCRIPTION
# What does this PR do?
`poptorch.autocasting` not needed now we have dispatch tracing. Also will be removed completely in SDK3.1.

* Remove the deprecated and now unused autocasting ipu options
* Update comment on casting in modelin

