### PR TITLE
Set enable half partials by default to True

### DIFF
--- a/optimum/graphcore/ipu_configuration.py
+++ b/optimum/graphcore/ipu_configuration.py
@@ -147,7 +147,7 @@ class IPUConfig(BaseConfig):
         if "enable_half_first_order_momentum" in kwargs:
             warnings.warn('The "enable_half_first_order_momentum" parameter is deprecated')
 
-        self.enable_half_partials = kwargs.pop("enable_half_partials", False)
+        self.enable_half_partials = kwargs.pop("enable_half_partials", True)
 
         self.executable_cache_dir = kwargs.pop("executable_cache_dir", "")
 


### PR DESCRIPTION
# What does this PR do?

* Half partials option is True in every single config, but the default `IPUConfig` object sets it to False by default.
* Set the default to True always.