### PR TITLE
Notebook-specific cache dirs

### DIFF
--- a/notebooks/audio_classification.ipynb
+++ b/notebooks/audio_classification.ipynb
@@ -58,7 +58,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_AUDIO_CLASSIFICATION\", \"/tmp/exe_cache/\")"
    ]
   },
   {

--- a/notebooks/audio_classification.ipynb
+++ b/notebooks/audio_classification.ipynb
@@ -58,7 +58,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_AUDIO_CLASSIFICATION\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/audio_classification\""
    ]
   },
   {

--- a/notebooks/external_model.ipynb
+++ b/notebooks/external_model.ipynb
@@ -54,7 +54,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_EXTERNAL_MODEL\", \"/tmp/exe_cache/\")"
    ]
   },
   {

--- a/notebooks/external_model.ipynb
+++ b/notebooks/external_model.ipynb
@@ -54,7 +54,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_EXTERNAL_MODEL\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/external_model\""
    ]
   },
   {

--- a/notebooks/image_classification.ipynb
+++ b/notebooks/image_classification.ipynb
@@ -65,7 +65,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_IMAGE_CLASSIFICATION\", \"/tmp/exe_cache/\")"
    ]
   },
   {

--- a/notebooks/image_classification.ipynb
+++ b/notebooks/image_classification.ipynb
@@ -65,7 +65,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_IMAGE_CLASSIFICATION\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/image_classification\""
    ]
   },
   {

--- a/notebooks/introduction_to_optimum_graphcore.ipynb
+++ b/notebooks/introduction_to_optimum_graphcore.ipynb
@@ -109,7 +109,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_INTRODUCTION_TO_OPTIMUM_GRAPHCORE\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/introduction_to_optimum_graphcore\""
    ]
   },
   {

--- a/notebooks/introduction_to_optimum_graphcore.ipynb
+++ b/notebooks/introduction_to_optimum_graphcore.ipynb
@@ -109,7 +109,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_INTRODUCTION_TO_OPTIMUM_GRAPHCORE\", \"/tmp/exe_cache/\")"
    ]
   },
   {

--- a/notebooks/language_modeling.ipynb
+++ b/notebooks/language_modeling.ipynb
@@ -97,7 +97,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_LANGUAGE_MODELING\", \"/tmp/exe_cache/\")"
    ]
   },
   {

--- a/notebooks/language_modeling.ipynb
+++ b/notebooks/language_modeling.ipynb
@@ -97,7 +97,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_LANGUAGE_MODELING\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/language_modeling\""
    ]
   },
   {

--- a/notebooks/language_modelling_from_scratch.ipynb
+++ b/notebooks/language_modelling_from_scratch.ipynb
@@ -90,7 +90,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_LANGUAGE_MODELLING_FROM_SCRATCH\", \"/tmp/exe_cache/\")"
    ]
   },
   {

--- a/notebooks/language_modelling_from_scratch.ipynb
+++ b/notebooks/language_modelling_from_scratch.ipynb
@@ -90,7 +90,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_LANGUAGE_MODELLING_FROM_SCRATCH\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/language_modelling_from_scratch\""
    ]
   },
   {

--- a/notebooks/multiple_choice.ipynb
+++ b/notebooks/multiple_choice.ipynb
@@ -97,7 +97,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_MULTIPLE_CHOICE\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/multiple_choice\""
    ]
   },
   {

--- a/notebooks/multiple_choice.ipynb
+++ b/notebooks/multiple_choice.ipynb
@@ -97,7 +97,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_MULTIPLE_CHOICE\", \"/tmp/exe_cache/\")"
    ]
   },
   {

--- a/notebooks/question_answering.ipynb
+++ b/notebooks/question_answering.ipynb
@@ -99,7 +99,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_QUESTION_ANSWERING\", \"/tmp/exe_cache/\")"
    ]
   },
   {

--- a/notebooks/question_answering.ipynb
+++ b/notebooks/question_answering.ipynb
@@ -99,7 +99,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_QUESTION_ANSWERING\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/question_answering\""
    ]
   },
   {

--- a/notebooks/stable_diffusion/image_to_image.ipynb
+++ b/notebooks/stable_diffusion/image_to_image.ipynb
@@ -42,7 +42,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_STABLE_DIFFUSION_IMG2IMG\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/stablediffusion_img2img\""
    ]
   },
   {

--- a/notebooks/stable_diffusion/image_to_image.ipynb
+++ b/notebooks/stable_diffusion/image_to_image.ipynb
@@ -42,7 +42,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_STABLE_DIFFUSION_IMG2IMG\", \"/tmp/exe_cache/\")"
    ]
   },
   {

--- a/notebooks/stable_diffusion/inpainting.ipynb
+++ b/notebooks/stable_diffusion/inpainting.ipynb
@@ -42,7 +42,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_STABLE_DIFFUSION_INPAINTING\", \"/tmp/exe_cache/\")"
    ]
   },
   {

--- a/notebooks/stable_diffusion/inpainting.ipynb
+++ b/notebooks/stable_diffusion/inpainting.ipynb
@@ -42,7 +42,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_STABLE_DIFFUSION_INPAINTING\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/stablediffusion_inpainting\""
    ]
   },
   {

--- a/notebooks/stable_diffusion/text_to_image.ipynb
+++ b/notebooks/stable_diffusion/text_to_image.ipynb
@@ -42,7 +42,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_STABLE_DIFFUSION_TEXT2IMG\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/stablediffusion_text2img\""
    ]
   },
   {

--- a/notebooks/stable_diffusion/text_to_image.ipynb
+++ b/notebooks/stable_diffusion/text_to_image.ipynb
@@ -42,7 +42,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_STABLE_DIFFUSION_TEXT2IMG\", \"/tmp/exe_cache/\")"
    ]
   },
   {

--- a/notebooks/summarization.ipynb
+++ b/notebooks/summarization.ipynb
@@ -97,7 +97,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_SUMMARIZATION\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/summarization\""
    ]
   },
   {

--- a/notebooks/summarization.ipynb
+++ b/notebooks/summarization.ipynb
@@ -97,7 +97,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_SUMMARIZATION\", \"/tmp/exe_cache/\")"
    ]
   },
   {

--- a/notebooks/text_classification.ipynb
+++ b/notebooks/text_classification.ipynb
@@ -113,7 +113,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_TEXT_CLASSIFICATION\", \"/tmp/exe_cache/\")"
    ]
   },
   {

--- a/notebooks/text_classification.ipynb
+++ b/notebooks/text_classification.ipynb
@@ -113,7 +113,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_TEXT_CLASSIFICATION\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/text_classification\""
    ]
   },
   {

--- a/notebooks/token_classification.ipynb
+++ b/notebooks/token_classification.ipynb
@@ -97,7 +97,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_TOKEN_CLASSIFICATION\", \"/tmp/exe_cache/\")"
    ]
   },
   {

--- a/notebooks/token_classification.ipynb
+++ b/notebooks/token_classification.ipynb
@@ -97,7 +97,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_TOKEN_CLASSIFICATION\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/token_classification\""
    ]
   },
   {

--- a/notebooks/translation.ipynb
+++ b/notebooks/translation.ipynb
@@ -97,7 +97,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_TRANSLATION\", \"/tmp/exe_cache/\")"
    ]
   },
   {

--- a/notebooks/translation.ipynb
+++ b/notebooks/translation.ipynb
@@ -97,7 +97,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_TRANSLATION\", \"/tmp/exe_cache/\")"
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/translation\""
    ]
   },
   {

--- a/notebooks/wav2vec2/wav2vec2-fine-tuning-checkpoint.ipynb
+++ b/notebooks/wav2vec2/wav2vec2-fine-tuning-checkpoint.ipynb
@@ -131,7 +131,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\")\n",
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_WAV2VEC2_FINE_TUNING\", \"/tmp/exe_cache/\")\n",
     "checkpoint_directory = Path(os.getenv(\"CHECKPOINT_DIR\", \"/tmp\")) / \"demo\""
    ]
   },

--- a/notebooks/wav2vec2/wav2vec2-fine-tuning-checkpoint.ipynb
+++ b/notebooks/wav2vec2/wav2vec2-fine-tuning-checkpoint.ipynb
@@ -131,7 +131,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_WAV2VEC2_FINE_TUNING\", \"/tmp/exe_cache/\")\n",
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/wav2vec2_fine_tuning\"\n",
     "checkpoint_directory = Path(os.getenv(\"CHECKPOINT_DIR\", \"/tmp\")) / \"demo\""
    ]
   },

--- a/notebooks/wav2vec2/wav2vec2-inference-checkpoint.ipynb
+++ b/notebooks/wav2vec2/wav2vec2-inference-checkpoint.ipynb
@@ -112,7 +112,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_WAV2VEC2_INFERENCE\", \"/tmp/exe_cache/\")\n",
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/wav2vec2_inference\"\n",
     "checkpoint_directory = Path(os.getenv(\"CHECKPOINT_DIR\", \"/tmp\")) / \"demo\""
    ]
   },

--- a/notebooks/wav2vec2/wav2vec2-inference-checkpoint.ipynb
+++ b/notebooks/wav2vec2/wav2vec2-inference-checkpoint.ipynb
@@ -112,7 +112,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\")\n",
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR_WAV2VEC2_INFERENCE\", \"/tmp/exe_cache/\")\n",
     "checkpoint_directory = Path(os.getenv(\"CHECKPOINT_DIR\", \"/tmp\")) / \"demo\""
    ]
   },


### PR DESCRIPTION
Change 

- Each notebook to have its own poplar executable cache directory. This is needed as a workaround to prevent long .popef file loading times over cloud networks, to ensure fast compilation times. 