### PR TITLE
text2img and img2img use the same cache

### DIFF
--- a/notebooks/stable_diffusion/image_to_image.ipynb
+++ b/notebooks/stable_diffusion/image_to_image.ipynb
@@ -42,7 +42,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/stablediffusion_img2img\""
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/stablediffusion_to-image\""
    ]
   },
   {

--- a/notebooks/stable_diffusion/text_to_image.ipynb
+++ b/notebooks/stable_diffusion/text_to_image.ipynb
@@ -42,7 +42,7 @@
     "import os\n",
     "\n",
     "pod_type = os.getenv(\"GRAPHCORE_POD_TYPE\", \"pod16\")\n",
-    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/stablediffusion_text2img\""
+    "executable_cache_dir = os.getenv(\"POPLAR_EXECUTABLE_CACHE_DIR\", \"/tmp/exe_cache/\") + \"/stablediffusion_to-image\""
    ]
   },
   {


### PR DESCRIPTION
The stable diffusion image_to_image and text_to_image notebooks use the same poplar executable, so this PR makes them use the same cache to prevent uploading a duplicate file