### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A Poplar SDK environment needs to be enabled to use this library. Please refer t
 ## Install
 To install the latest release of this package:
 
-`pip install optimum[graphcore]`
+`pip install optimum-graphcore`
 
 Optimum Graphcore is a fast-moving project, and you may want to install from source.
 

--- a/notebooks/image_classification.ipynb
+++ b/notebooks/image_classification.ipynb
@@ -89,7 +89,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install -q \"optimum-graphcore>0.4, <0.5\" scikit-learn torchvision==0.11.1"
+    "%pip install -q \"optimum-graphcore>0.4, <0.5\" scikit-learn torchvision==0.11.0+cpu -f https://download.pytorch.org/whl/torch_stable.html"
    ]
   },
   {
@@ -1291,7 +1291,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3.8.10 ('3.0.0+1145_poptorch')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
# What does this PR do?

`pip install optimum[graphcore]` is installing the wrong version due to pip's dependency solver doing the wrong thing.
Changing to `pip install optimum-graphcore` installs the newest version. 