### PR TITLE
detach from IPUs to free resources

### DIFF
--- a/notebooks/sentiment_analysis.ipynb
+++ b/notebooks/sentiment_analysis.ipynb
@@ -584,6 +584,8 @@
    "outputs": [],
    "source": [
     "sentiment_pipeline.model.detachFromDevice()\n",
+    "tweet21_pipeline.model.detachFromDevice()\n",
+    "multilingual_pipeline.model.detachFromDevice()\n",
     "emotion_pipeline.model.detachFromDevice()"
    ]
   },


### PR DESCRIPTION
We add more explicit "detachFromDevice()" calls to free up IPU resources so models in upcoming cells have IPUs to attach to.