### PR TITLE
remove markdown text referencing gpu

### DIFF
--- a/notebooks/question_answering.ipynb
+++ b/notebooks/question_answering.ipynb
@@ -105,15 +105,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "HFASsisvIrIb"
-   },
-   "source": [
-    "You can find a script version of this notebook to fine-tune your model in a distributed fashion using multiple GPUs or TPUs [here](https://github.com/huggingface/transformers/tree/master/examples/question-answering)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "id": "rEJBSTyZIrIb"
    },
    "source": [


### PR DESCRIPTION
This PR removes a markdown cell that references GPU and TPU