### PR TITLE
adding packed bert squad notebook

### DIFF
--- a/notebooks/packedBERT_question_answering.ipynb
+++ b/notebooks/packedBERT_question_answering.ipynb
@@ -1,0 +1,2942 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ea524730",
+   "metadata": {},
+   "source": [
+    "## Fine-tuning BERT on the SQuAD dataset for question answering\n",
+    "\n",
+    "This notebook describes how to fine-tune BERT from [🤗 Transformers](https://github.com/huggingface/transformers) for question-answering using the SQuAD(v1) dataset. This is demonstrated using a [packed](https://towardsdatascience.com/introducing-packed-bert-for-2x-faster-training-in-natural-language-processing-eadb749962b1) dataset, borrowing the dataset packing technique previously developed for BERT pre-training and applying it to a smaller fine-tuning task for improved throughput.  The process of training and validating the `BertForQuestionAnswering` model requires some adaptations to accommodate a packed dataset, and this notebook aims to introduce these on top of the [existing process](https://github.com/huggingface/optimum-graphcore/blob/main/notebooks/question_answering.ipynb) for fine-tuning the SQuAD dataset with BERT using an unmodified dataset."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af68e25d",
+   "metadata": {},
+   "source": [
+    "### 1. Setting up packages and configurations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51b0ba30",
+   "metadata": {},
+   "source": [
+    "First of all, ensure your environment has the latest version of  [🤗 Optimum Graphcore](https://github.com/huggingface/optimum-graphcore) installed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4ad38948",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Looking in indexes: https://arsalanu%40graphcore.ai:****@artifactory.sourcevertex.net:443/api/pypi/pypi-virtual/simple, https://pypi.python.org/simple/\n",
+      "Requirement already satisfied: optimum[graphcore] in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (1.5.2.dev0)\n",
+      "Requirement already satisfied: transformers[sentencepiece]>=4.20.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from optimum[graphcore]) (4.20.1)\n",
+      "Requirement already satisfied: packaging in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from optimum[graphcore]) (21.3)\n",
+      "Requirement already satisfied: coloredlogs in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from optimum[graphcore]) (15.0.1)\n",
+      "Requirement already satisfied: sympy in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from optimum[graphcore]) (1.11.1)\n",
+      "Requirement already satisfied: huggingface-hub>=0.8.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from optimum[graphcore]) (0.10.1)\n",
+      "Requirement already satisfied: numpy in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from optimum[graphcore]) (1.23.4)\n",
+      "Requirement already satisfied: torch>=1.9 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from optimum[graphcore]) (1.10.0+cpu)\n",
+      "Requirement already satisfied: optimum-graphcore in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from optimum[graphcore]) (0.4.2.dev0)\n",
+      "Requirement already satisfied: typing-extensions>=3.7.4.3 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from huggingface-hub>=0.8.0->optimum[graphcore]) (4.4.0)\n",
+      "Requirement already satisfied: requests in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from huggingface-hub>=0.8.0->optimum[graphcore]) (2.28.1)\n",
+      "Requirement already satisfied: filelock in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from huggingface-hub>=0.8.0->optimum[graphcore]) (3.8.0)\n",
+      "Requirement already satisfied: tqdm in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from huggingface-hub>=0.8.0->optimum[graphcore]) (4.64.1)\n",
+      "Requirement already satisfied: pyyaml>=5.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from huggingface-hub>=0.8.0->optimum[graphcore]) (6.0)\n",
+      "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from packaging->optimum[graphcore]) (3.0.9)\n",
+      "Requirement already satisfied: regex!=2019.12.17 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from transformers[sentencepiece]>=4.20.1->optimum[graphcore]) (2022.10.31)\n",
+      "Requirement already satisfied: tokenizers!=0.11.3,<0.13,>=0.11.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from transformers[sentencepiece]>=4.20.1->optimum[graphcore]) (0.12.1)\n",
+      "Requirement already satisfied: protobuf<=3.20.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from transformers[sentencepiece]>=4.20.1->optimum[graphcore]) (3.20.1)\n",
+      "Requirement already satisfied: sentencepiece!=0.1.92,>=0.1.91 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from transformers[sentencepiece]>=4.20.1->optimum[graphcore]) (0.1.97)\n",
+      "Requirement already satisfied: humanfriendly>=9.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from coloredlogs->optimum[graphcore]) (10.0)\n",
+      "Requirement already satisfied: pillow in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from optimum-graphcore->optimum[graphcore]) (9.3.0)\n",
+      "Requirement already satisfied: scipy in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from optimum-graphcore->optimum[graphcore]) (1.9.3)\n",
+      "Requirement already satisfied: datasets in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from optimum-graphcore->optimum[graphcore]) (2.6.1)\n",
+      "Requirement already satisfied: mpmath>=0.19 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from sympy->optimum[graphcore]) (1.2.1)\n",
+      "Requirement already satisfied: responses<0.19 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets->optimum-graphcore->optimum[graphcore]) (0.18.0)\n",
+      "Requirement already satisfied: aiohttp in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets->optimum-graphcore->optimum[graphcore]) (3.8.3)\n",
+      "Requirement already satisfied: xxhash in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets->optimum-graphcore->optimum[graphcore]) (3.1.0)\n",
+      "Requirement already satisfied: pandas in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets->optimum-graphcore->optimum[graphcore]) (1.5.1)\n",
+      "Requirement already satisfied: fsspec[http]>=2021.11.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets->optimum-graphcore->optimum[graphcore]) (2022.11.0)\n",
+      "Requirement already satisfied: pyarrow>=6.0.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets->optimum-graphcore->optimum[graphcore]) (10.0.0)\n",
+      "Requirement already satisfied: multiprocess in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets->optimum-graphcore->optimum[graphcore]) (0.70.13)\n",
+      "Requirement already satisfied: dill<0.3.6 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets->optimum-graphcore->optimum[graphcore]) (0.3.5.1)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from requests->huggingface-hub>=0.8.0->optimum[graphcore]) (3.4)\n",
+      "Requirement already satisfied: charset-normalizer<3,>=2 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from requests->huggingface-hub>=0.8.0->optimum[graphcore]) (2.1.1)\n",
+      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from requests->huggingface-hub>=0.8.0->optimum[graphcore]) (1.26.12)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from requests->huggingface-hub>=0.8.0->optimum[graphcore]) (2022.9.24)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: yarl<2.0,>=1.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets->optimum-graphcore->optimum[graphcore]) (1.8.1)\n",
+      "Requirement already satisfied: aiosignal>=1.1.2 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets->optimum-graphcore->optimum[graphcore]) (1.3.1)\n",
+      "Requirement already satisfied: async-timeout<5.0,>=4.0.0a3 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets->optimum-graphcore->optimum[graphcore]) (4.0.2)\n",
+      "Requirement already satisfied: frozenlist>=1.1.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets->optimum-graphcore->optimum[graphcore]) (1.3.3)\n",
+      "Requirement already satisfied: attrs>=17.3.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets->optimum-graphcore->optimum[graphcore]) (22.1.0)\n",
+      "Requirement already satisfied: multidict<7.0,>=4.5 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets->optimum-graphcore->optimum[graphcore]) (6.0.2)\n",
+      "Requirement already satisfied: pytz>=2020.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from pandas->datasets->optimum-graphcore->optimum[graphcore]) (2022.6)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from pandas->datasets->optimum-graphcore->optimum[graphcore]) (2.8.2)\n",
+      "Requirement already satisfied: six>=1.5 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from python-dateutil>=2.8.1->pandas->datasets->optimum-graphcore->optimum[graphcore]) (1.16.0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "! pip install optimum[graphcore]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b26df2b4",
+   "metadata": {},
+   "source": [
+    "Next, ensure all required packages for the model training workflow are installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e98ec027",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Looking in indexes: https://arsalanu%40graphcore.ai:****@artifactory.sourcevertex.net:443/api/pypi/pypi-virtual/simple, https://pypi.python.org/simple/\n",
+      "Requirement already satisfied: transformers==4.20.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (4.20.1)\n",
+      "Requirement already satisfied: huggingface-hub<1.0,>=0.1.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from transformers==4.20.1) (0.10.1)\n",
+      "Requirement already satisfied: tqdm>=4.27 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from transformers==4.20.1) (4.64.1)\n",
+      "Requirement already satisfied: filelock in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from transformers==4.20.1) (3.8.0)\n",
+      "Requirement already satisfied: tokenizers!=0.11.3,<0.13,>=0.11.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from transformers==4.20.1) (0.12.1)\n",
+      "Requirement already satisfied: pyyaml>=5.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from transformers==4.20.1) (6.0)\n",
+      "Requirement already satisfied: requests in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from transformers==4.20.1) (2.28.1)\n",
+      "Requirement already satisfied: regex!=2019.12.17 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from transformers==4.20.1) (2022.10.31)\n",
+      "Requirement already satisfied: numpy>=1.17 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from transformers==4.20.1) (1.23.4)\n",
+      "Requirement already satisfied: packaging>=20.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from transformers==4.20.1) (21.3)\n",
+      "Requirement already satisfied: typing-extensions>=3.7.4.3 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from huggingface-hub<1.0,>=0.1.0->transformers==4.20.1) (4.4.0)\n",
+      "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from packaging>=20.0->transformers==4.20.1) (3.0.9)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from requests->transformers==4.20.1) (2022.9.24)\n",
+      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from requests->transformers==4.20.1) (1.26.12)\n",
+      "Requirement already satisfied: charset-normalizer<3,>=2 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from requests->transformers==4.20.1) (2.1.1)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from requests->transformers==4.20.1) (3.4)\n",
+      "Looking in indexes: https://arsalanu%40graphcore.ai:****@artifactory.sourcevertex.net:443/api/pypi/pypi-virtual/simple, https://pypi.python.org/simple/\n",
+      "Requirement already satisfied: datasets in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (2.6.1)\n",
+      "Requirement already satisfied: tqdm>=4.62.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets) (4.64.1)\n",
+      "Requirement already satisfied: multiprocess in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets) (0.70.13)\n",
+      "Requirement already satisfied: aiohttp in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets) (3.8.3)\n",
+      "Requirement already satisfied: pandas in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets) (1.5.1)\n",
+      "Requirement already satisfied: dill<0.3.6 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets) (0.3.5.1)\n",
+      "Requirement already satisfied: packaging in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets) (21.3)\n",
+      "Requirement already satisfied: numpy>=1.17 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets) (1.23.4)\n",
+      "Requirement already satisfied: huggingface-hub<1.0.0,>=0.2.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets) (0.10.1)\n",
+      "Requirement already satisfied: pyarrow>=6.0.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets) (10.0.0)\n",
+      "Requirement already satisfied: pyyaml>=5.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets) (6.0)\n",
+      "Requirement already satisfied: responses<0.19 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets) (0.18.0)\n",
+      "Requirement already satisfied: fsspec[http]>=2021.11.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets) (2022.11.0)\n",
+      "Requirement already satisfied: xxhash in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets) (3.1.0)\n",
+      "Requirement already satisfied: requests>=2.19.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets) (2.28.1)\n",
+      "Requirement already satisfied: frozenlist>=1.1.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets) (1.3.3)\n",
+      "Requirement already satisfied: async-timeout<5.0,>=4.0.0a3 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets) (4.0.2)\n",
+      "Requirement already satisfied: attrs>=17.3.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets) (22.1.0)\n",
+      "Requirement already satisfied: charset-normalizer<3.0,>=2.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets) (2.1.1)\n",
+      "Requirement already satisfied: aiosignal>=1.1.2 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets) (1.3.1)\n",
+      "Requirement already satisfied: multidict<7.0,>=4.5 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets) (6.0.2)\n",
+      "Requirement already satisfied: yarl<2.0,>=1.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets) (1.8.1)\n",
+      "Requirement already satisfied: filelock in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from huggingface-hub<1.0.0,>=0.2.0->datasets) (3.8.0)\n",
+      "Requirement already satisfied: typing-extensions>=3.7.4.3 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from huggingface-hub<1.0.0,>=0.2.0->datasets) (4.4.0)\n",
+      "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from packaging->datasets) (3.0.9)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: idna<4,>=2.5 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from requests>=2.19.0->datasets) (3.4)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from requests>=2.19.0->datasets) (2022.9.24)\n",
+      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from requests>=2.19.0->datasets) (1.26.12)\n",
+      "Requirement already satisfied: pytz>=2020.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from pandas->datasets) (2022.6)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from pandas->datasets) (2.8.2)\n",
+      "Requirement already satisfied: six>=1.5 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from python-dateutil>=2.8.1->pandas->datasets) (1.16.0)\n",
+      "Looking in indexes: https://arsalanu%40graphcore.ai:****@artifactory.sourcevertex.net:443/api/pypi/pypi-virtual/simple, https://pypi.python.org/simple/\n",
+      "Requirement already satisfied: evaluate in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (0.4.0)\n",
+      "Requirement already satisfied: datasets>=2.0.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from evaluate) (2.6.1)\n",
+      "Requirement already satisfied: numpy>=1.17 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from evaluate) (1.23.4)\n",
+      "Requirement already satisfied: packaging in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from evaluate) (21.3)\n",
+      "Requirement already satisfied: tqdm>=4.62.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from evaluate) (4.64.1)\n",
+      "Requirement already satisfied: multiprocess in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from evaluate) (0.70.13)\n",
+      "Requirement already satisfied: fsspec[http]>=2021.05.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from evaluate) (2022.11.0)\n",
+      "Requirement already satisfied: responses<0.19 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from evaluate) (0.18.0)\n",
+      "Requirement already satisfied: requests>=2.19.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from evaluate) (2.28.1)\n",
+      "Requirement already satisfied: pandas in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from evaluate) (1.5.1)\n",
+      "Requirement already satisfied: dill in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from evaluate) (0.3.5.1)\n",
+      "Requirement already satisfied: xxhash in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from evaluate) (3.1.0)\n",
+      "Requirement already satisfied: huggingface-hub>=0.7.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from evaluate) (0.10.1)\n",
+      "Requirement already satisfied: pyarrow>=6.0.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets>=2.0.0->evaluate) (10.0.0)\n",
+      "Requirement already satisfied: pyyaml>=5.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets>=2.0.0->evaluate) (6.0)\n",
+      "Requirement already satisfied: aiohttp in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from datasets>=2.0.0->evaluate) (3.8.3)\n",
+      "Requirement already satisfied: filelock in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from huggingface-hub>=0.7.0->evaluate) (3.8.0)\n",
+      "Requirement already satisfied: typing-extensions>=3.7.4.3 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from huggingface-hub>=0.7.0->evaluate) (4.4.0)\n",
+      "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from packaging->evaluate) (3.0.9)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from requests>=2.19.0->evaluate) (3.4)\n",
+      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from requests>=2.19.0->evaluate) (1.26.12)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from requests>=2.19.0->evaluate) (2022.9.24)\n",
+      "Requirement already satisfied: charset-normalizer<3,>=2 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from requests>=2.19.0->evaluate) (2.1.1)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from pandas->evaluate) (2.8.2)\n",
+      "Requirement already satisfied: pytz>=2020.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from pandas->evaluate) (2022.6)\n",
+      "Requirement already satisfied: frozenlist>=1.1.1 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets>=2.0.0->evaluate) (1.3.3)\n",
+      "Requirement already satisfied: async-timeout<5.0,>=4.0.0a3 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets>=2.0.0->evaluate) (4.0.2)\n",
+      "Requirement already satisfied: yarl<2.0,>=1.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets>=2.0.0->evaluate) (1.8.1)\n",
+      "Requirement already satisfied: multidict<7.0,>=4.5 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets>=2.0.0->evaluate) (6.0.2)\n",
+      "Requirement already satisfied: attrs>=17.3.0 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets>=2.0.0->evaluate) (22.1.0)\n",
+      "Requirement already satisfied: aiosignal>=1.1.2 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from aiohttp->datasets>=2.0.0->evaluate) (1.3.1)\n",
+      "Requirement already satisfied: six>=1.5 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from python-dateutil>=2.8.1->pandas->evaluate) (1.16.0)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Looking in indexes: https://arsalanu%40graphcore.ai:****@artifactory.sourcevertex.net:443/api/pypi/pypi-virtual/simple, https://pypi.python.org/simple/\n",
+      "Requirement already satisfied: scipy in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (1.9.3)\n",
+      "Requirement already satisfied: numpy<1.26.0,>=1.18.5 in /localdata/arsalanu/popsdk_venvs/poplar_sdk-ubuntu_20_04-3.0.0+1145-1b114aac3a/3.0.0+1145_poptorch/lib/python3.8/site-packages (from scipy) (1.23.4)\n"
+     ]
+    }
+   ],
+   "source": [
+    "! pip install transformers==4.20.1\n",
+    "! pip install datasets\n",
+    "! pip install evaluate\n",
+    "! pip install scipy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df689f96",
+   "metadata": {},
+   "source": [
+    "Let's start by importing the `transformers` and `optimum.graphcore` libraries, and printing the versions we are using."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "aa8d39f7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4.20.1\n",
+      "0.4.2.dev0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import transformers\n",
+    "import optimum.graphcore\n",
+    "print(transformers.__version__)\n",
+    "print(optimum.graphcore.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "802f03f9",
+   "metadata": {},
+   "source": [
+    "Next, import further dependencies needed throughout the workflow. To maintain comparable results over repeated runs of training and validation, make sure to set the random seed for `torch` and `numpy` to a pre-defined value. This will ensure all randomness within our model remains constant when re-initialising."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ab889f2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import numpy as np\n",
+    "\n",
+    "torch.manual_seed(1234)\n",
+    "np.random.seed(5678)\n",
+    "\n",
+    "import time\n",
+    "from tqdm.notebook import tqdm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89898522",
+   "metadata": {},
+   "source": [
+    "Let's initialise our training configurations. \n",
+    "\n",
+    "Note here that we define a 'micro' batch size, which is the local batch size that would be passed into the model on the CPU. In this notebook, we are using both data parallelism and pipeline parallelism (see this [tutorial](https://github.com/graphcore/tutorials/tree/master/tutorials/pytorch/efficient_data_loading)), so the 'global' batch size, i.e. the number of data elements passed for one gradient calculation on the IPU, is calculated using the `device_iterations`, `gradient_accumulation_steps`, `replication_factor` and `max_seq_per_pack` (maximum sequences in a pack) for training, such that:\n",
+    "\n",
+    "```\n",
+    "global_training_batch_size=device_iterations*gradient_accumulation_steps*replication_factor\n",
+    "```\n",
+    "\n",
+    "Depending on you model and the pod machine you are using, you might need to adjust these three batch-size-related arguments.\n",
+    "\n",
+    "`max_seq_per_pack` highlights the benefit of packing multiple sequences into one input sequence given there is enough space for them. It shows that multiple sequences are processed effectively in parallel within the model, using up space that would essentially be padding if one sequence were passed at a time. This is a much more efficient way to send inputs into the model, and improves the global batch size to a best-case-scenario of:\n",
+    "\n",
+    "```\n",
+    "global_training_batch_size=device_iterations*gradient_accumulation_steps*replication_factor*max_seq_per_pack\n",
+    "```\n",
+    "\n",
+    "Realistically, the global batch size will not always be multiplied by the *maximum* number of sequences in a packed sequence, but rather the *average* number of sequences in a packed sequence, and will depend on the sequence length distribution within any given dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0ad1b478",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_checkpoint=\"bert-base-uncased\" # Default uncased pre-trained BERT checkpoint\n",
+    "ipu_config_name=\"Graphcore/bert-base-uncased\" # Default Graphcore IPU config initialisation for pre-trained BERT\n",
+    "max_seq_length=384 # The maximum sequence length allowed for sequences in the model.\n",
+    "max_seq_per_pack=3 # The maximum number of sequences that can be packed into a single packed input sequence.\n",
+    "\n",
+    "micro_batch_size_train=1 # Local batch size used during training.\n",
+    "micro_batch_size_eval=8  # Local batch size used during validation.\n",
+    "gradient_accumulation_steps=32 # Gradient accumulation steps for training the model on the IPU.\n",
+    "device_iterations=16 # Device iterations for training the model on the IPU.\n",
+    "replication_factor=1 # Replication of the model across this many sets of IPUs.\n",
+    "pod_type=\"pod4\" # The model is configured to run on a POD with 4 IPUs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77dde875",
+   "metadata": {},
+   "source": [
+    "Gradients are not calculated during validation, so gradient accumulation is not applicable, and the global batch size for validation can be defined separately as:\n",
+    "\n",
+    "```\n",
+    "global_validation_batch_size=device_iterations*replication_factor*max_seq_per_pack\n",
+    "```\n",
+    "\n",
+    "In Optimum, we can define inference-specific `device iterations` and `replication factor`, which can be adjusted to create larger batches to complensate for the lack of a gradient accumulation factor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "44a38904",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device_iterations_val=64 # Device iterations for validating the model on the IPU.\n",
+    "replication_factor_val=1 # Replication factor for validating the model on the IPU."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33597c71",
+   "metadata": {},
+   "source": [
+    "### 2. Preprocessing and tokenising the dataset\n",
+    "\n",
+    "The next step is to use the [🤗 Datasets](https://github.com/huggingface/datasets) library to download the dataset from the hub, and to use the  [🤗 Evaluate](https://github.com/huggingface/evaluate) library to load the evaluation metrics for the SQuAD model. This will allow easy performance metric analysis during validation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b37cb293",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Found cached dataset squad (/home/arsalanu/.cache/huggingface/datasets/squad/plain_text/1.0.0/d6ec3ceb99ca480ce37cdd35555d6cb2511d223b9150cce08a837ef62ffea453)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b90b7fd6229541fab496acfc0bd09866",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from datasets import load_dataset, load_metric\n",
+    "import evaluate\n",
+    "\n",
+    "model_task=\"squad\" \n",
+    "\n",
+    "dataset = load_dataset(model_task) # Load dataset\n",
+    "metric = evaluate.load(model_task) # Load metric for dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6dac6eca",
+   "metadata": {},
+   "source": [
+    "The `dataset` object itself is [`DatasetDict`](https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasetdict), which contains one key for the training, validation and test set:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "2115928b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatasetDict({\n",
+       "    train: Dataset({\n",
+       "        features: ['id', 'title', 'context', 'question', 'answers'],\n",
+       "        num_rows: 87599\n",
+       "    })\n",
+       "    validation: Dataset({\n",
+       "        features: ['id', 'title', 'context', 'question', 'answers'],\n",
+       "        num_rows: 10570\n",
+       "    })\n",
+       "})"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23d3f421",
+   "metadata": {},
+   "source": [
+    "To access an actual element, you need to select a split first, then provide an index:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "311b8b73",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': '5733be284776f41900661182',\n",
+       " 'title': 'University_of_Notre_Dame',\n",
+       " 'context': 'Architecturally, the school has a Catholic character. Atop the Main Building\\'s gold dome is a golden statue of the Virgin Mary. Immediately in front of the Main Building and facing it, is a copper statue of Christ with arms upraised with the legend \"Venite Ad Me Omnes\". Next to the Main Building is the Basilica of the Sacred Heart. Immediately behind the basilica is the Grotto, a Marian place of prayer and reflection. It is a replica of the grotto at Lourdes, France where the Virgin Mary reputedly appeared to Saint Bernadette Soubirous in 1858. At the end of the main drive (and in a direct line that connects through 3 statues and the Gold Dome), is a simple, modern stone statue of Mary.',\n",
+       " 'question': 'To whom did the Virgin Mary allegedly appear in 1858 in Lourdes France?',\n",
+       " 'answers': {'text': ['Saint Bernadette Soubirous'], 'answer_start': [515]}}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset[\"train\"][0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3702f2a3",
+   "metadata": {},
+   "source": [
+    "In the SQuAD dataset, we have a `question`, its `context` i.e., an excerpt of text which includes the answer as well as surrounding context, and the `answer` key, which holds the start position of the answer in the context, as well as the answer itself. For a different or custom question-answering dataset, these fields may have different names but serve the same purpose, so pre-defining them is useful.\n",
+    "\n",
+    "It is also useful to have a configuration describing these necessary keys in the dataset containing the raw data that needs to be pre-processed or tokenised before being passed into the model. These generic keys may change for custom datasets, but the usage of them generally stays the same for a similar fine-tuning task."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "628bc41f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "question_key=\"question\"\n",
+    "context_key=\"context\"\n",
+    "answer_key=\"answers\"\n",
+    "train = True\n",
+    "validate = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "793dcd19",
+   "metadata": {},
+   "source": [
+    "**Tokenizing the dataset:**\n",
+    "\n",
+    "Before we can feed those texts to our model, we need to preprocess them. This is done by a 🤗 Transformers `Tokenizer` which will (as the name indicates) tokenize the inputs (including converting the tokens to their corresponding IDs in the pretrained vocabulary) and put it in a format the model expects, as well as generate the other inputs that model requires.\n",
+    "\n",
+    "To do all of this, we instantiate our tokenizer with the `AutoTokenizer.from_pretrained` method, which will ensure:\n",
+    "\n",
+    "- we get a tokenizer that corresponds to the model architecture we want to use,\n",
+    "- we download the vocabulary used when pretraining this specific checkpoint.\n",
+    "\n",
+    "That vocabulary will be cached, so it's not downloaded again the next time we run the cell.\n",
+    "\n",
+    "The `Dataset` method is also imported, which will allow us to convert our modified and tokenized dataset in dictionary form to a PyTorch dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "aab94819",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import AutoTokenizer\n",
+    "from datasets import Dataset \n",
+    "\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_checkpoint, use_fast=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a47ea927",
+   "metadata": {},
+   "source": [
+    "For SQuAD, we define a custom function to handle the overflows and offset mapping created by generating tokenised inputs from sequences, as well as the start and end positions of the answers which need to be translated from positions of characters to positions of tokens.\n",
+    "\n",
+    "The first step is to tokenize the dataset using the tokenizer. Note here that for packing, it is important to **not** pad the dataset, so `padding` should be set to `False`. If we pad, we will have to un-pad when packing sequences into a packed sequence, which is inefficient. Also, to allow this notebook to be adaptable to different kinds of models, we need to account for the special case where the model expects padding on the left (in which case the order of the question and the context can be switched)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "27ec37d0",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "pad_on_right = tokenizer.padding_side == \"right\"\n",
+    "\n",
+    "tokenized_dataset = tokenizer(\n",
+    "        dataset[\"train\"][question_key if pad_on_right else context_key],\n",
+    "        dataset[\"train\"][context_key if pad_on_right else question_key],\n",
+    "        truncation=\"only_second\" if pad_on_right else \"only_first\",\n",
+    "        max_length=max_seq_length,\n",
+    "        return_overflowing_tokens=True,\n",
+    "        return_offsets_mapping=True,\n",
+    "        padding=False\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab3d81a1",
+   "metadata": {},
+   "source": [
+    "We can observe one of these tokenised inputs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "e3a85361",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[101, 2000, 3183, 2106, 1996, 6261, 2984, 9382, 3711, 1999, 8517, 1999, 10223, 26371, 2605, 1029, 102, 6549, 2135, 1010, 1996, 2082, 2038, 1037, 3234, 2839, 1012, 10234, 1996, 2364, 2311, 1005, 1055, 2751, 8514, 2003, 1037, 3585, 6231, 1997, 1996, 6261, 2984, 1012, 3202, 1999, 2392, 1997, 1996, 2364, 2311, 1998, 5307, 2009, 1010, 2003, 1037, 6967, 6231, 1997, 4828, 2007, 2608, 2039, 14995, 6924, 2007, 1996, 5722, 1000, 2310, 3490, 2618, 4748, 2033, 18168, 5267, 1000, 1012, 2279, 2000, 1996, 2364, 2311, 2003, 1996, 13546, 1997, 1996, 6730, 2540, 1012, 3202, 2369, 1996, 13546, 2003, 1996, 24665, 23052, 1010, 1037, 14042, 2173, 1997, 7083, 1998, 9185, 1012, 2009, 2003, 1037, 15059, 1997, 1996, 24665, 23052, 2012, 10223, 26371, 1010, 2605, 2073, 1996, 6261, 2984, 22353, 2135, 2596, 2000, 3002, 16595, 9648, 4674, 2061, 12083, 9711, 2271, 1999, 8517, 1012, 2012, 1996, 2203, 1997, 1996, 2364, 3298, 1006, 1998, 1999, 1037, 3622, 2240, 2008, 8539, 2083, 1017, 11342, 1998, 1996, 2751, 8514, 1007, 1010, 2003, 1037, 3722, 1010, 2715, 2962, 6231, 1997, 2984, 1012, 102]\n",
+      "[CLS] to whom did the virgin mary allegedly appear in 1858 in lourdes france? [SEP] architecturally, the school has a catholic character. atop the main building's gold dome is a golden statue of the virgin mary. immediately in front of the main building and facing it, is a copper statue of christ with arms upraised with the legend \" venite ad me omnes \". next to the main building is the basilica of the sacred heart. immediately behind the basilica is the grotto, a marian place of prayer and reflection. it is a replica of the grotto at lourdes, france where the virgin mary reputedly appeared to saint bernadette soubirous in 1858. at the end of the main drive ( and in a direct line that connects through 3 statues and the gold dome ), is a simple, modern stone statue of mary. [SEP]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(tokenized_dataset['input_ids'][0])\n",
+    "print(tokenizer.decode(tokenized_dataset['input_ids'][0]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e4003b9",
+   "metadata": {},
+   "source": [
+    "Now, converting the character-level answers and context into tokenized inputs creates extra work when trying to retrieve the character-level outputs and answers during postprocessing. We need to find out first which of the features the answer is actually in, and where - at the character level - the answer starts and ends within that feature. The tokenizer can help us with this by providing an `offset_mapping`.\n",
+    "\n",
+    "This outlines the equivalent character spans of the word which each token in `input_ids` represents, for each word in a sequence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "e77f6bf8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(0, 0), (0, 2), (3, 7), (8, 11), (12, 15), (16, 22), (23, 27), (28, 37), (38, 44), (45, 47), (48, 52), (53, 55), (56, 59), (59, 63), (64, 70), (70, 71), (0, 0), (0, 13), (13, 15), (15, 16), (17, 20), (21, 27), (28, 31), (32, 33), (34, 42), (43, 52), (52, 53), (54, 58), (59, 62), (63, 67), (68, 76), (76, 77), (77, 78), (79, 83), (84, 88), (89, 91), (92, 93), (94, 100), (101, 107), (108, 110), (111, 114), (115, 121), (122, 126), (126, 127), (128, 139), (140, 142), (143, 148), (149, 151), (152, 155), (156, 160), (161, 169), (170, 173), (174, 180), (181, 183), (183, 184), (185, 187), (188, 189), (190, 196), (197, 203), (204, 206), (207, 213), (214, 218), (219, 223), (224, 226), (226, 229), (229, 232), (233, 237), (238, 241), (242, 248), (249, 250), (250, 252), (252, 254), (254, 256), (257, 259), (260, 262), (263, 265), (265, 268), (268, 269), (269, 270), (271, 275), (276, 278), (279, 282), (283, 287), (288, 296), (297, 299), (300, 303), (304, 312), (313, 315), (316, 319), (320, 326), (327, 332), (332, 333), (334, 345), (346, 352), (353, 356), (357, 365), (366, 368), (369, 372), (373, 375), (375, 379)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(tokenized_dataset[\"offset_mapping\"][0][:100]) # Lets only print the first 100 character spans for this sequence"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90848ae7",
+   "metadata": {},
+   "source": [
+    "The very first token is the `[CLS]` token, with a character span of (0,0) as as it doesn't correspond to any part of the text, but rather is an indicator of the start of the sequence. This is also true for the `[SEP]` token indicating the end of a section and start of a new section within the sequence."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "599f166b",
+   "metadata": {},
+   "source": [
+    "We can use this mapping to find the position of the start and end tokens of our answer in a given feature. We just have to distinguish which parts of the offsets correspond to the question and which part correspond to the context, this is where the sequence_ids method of our tokenized_example can be useful:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "ea0df70c",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[None, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, None, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, None]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(tokenized_dataset.sequence_ids(0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e39e878",
+   "metadata": {},
+   "source": [
+    "It returns `None` for the special tokens, then 0 or 1 depending on whether the corresponding token comes from the first sentence past (the question) or the second (the context). Now with all of this, we can find the first and last token of the answer in one of our input feature (or if the answer is not in this feature):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "4cd32132",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "130 137\n"
+     ]
+    }
+   ],
+   "source": [
+    "answers = dataset[\"train\"][\"answers\"][0]\n",
+    "start_char = answers[\"answer_start\"][0]\n",
+    "end_char = start_char + len(answers[\"text\"][0])\n",
+    "\n",
+    "sequence_ids = tokenized_dataset.sequence_ids(0)\n",
+    "\n",
+    "# Start token index of the current span in the text.\n",
+    "token_start_index = 0\n",
+    "while sequence_ids[token_start_index] != 1:\n",
+    "    token_start_index += 1\n",
+    "\n",
+    "# End token index of the current span in the text.\n",
+    "token_end_index = len(tokenized_dataset[\"input_ids\"][0]) - 1\n",
+    "while sequence_ids[token_end_index] != 1:\n",
+    "    token_end_index -= 1\n",
+    "\n",
+    "# Detect if the answer is out of the span (in which case this feature is labeled with the CLS index).\n",
+    "offsets = tokenized_dataset[\"offset_mapping\"][0]\n",
+    "if (offsets[token_start_index][0] <= start_char and offsets[token_end_index][1] >= end_char):\n",
+    "    # Move the token_start_index and token_end_index to the two ends of the answer.\n",
+    "    # Note: we could go after the last offset if the answer is the last word (edge case).\n",
+    "    while token_start_index < len(offsets) and offsets[token_start_index][0] <= start_char:\n",
+    "        token_start_index += 1\n",
+    "    start_position = token_start_index - 1\n",
+    "    while offsets[token_end_index][1] >= end_char:\n",
+    "        token_end_index -= 1\n",
+    "    end_position = token_end_index + 1\n",
+    "    print(start_position, end_position)\n",
+    "else:\n",
+    "    print(\"The answer is not in this feature.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a1942f1",
+   "metadata": {},
+   "source": [
+    "We can double check that this is indeed the theoretical answer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "10607597",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "saint bernadette soubirous\n",
+      "Saint Bernadette Soubirous\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(tokenizer.decode(tokenized_dataset[\"input_ids\"][0][start_position: end_position+1]))\n",
+    "print(answers[\"text\"][0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c348ae9",
+   "metadata": {},
+   "source": [
+    "Next, let's take a look at what needs to be done for the validation process. The key difference between this and training is that there is no need to generate the offset mapping as part of the tokenisation process. For SQuAD, a custom postprocessing function is used to directly generate and compare the decoded output answer to the target answers.\n",
+    "\n",
+    "For the validation dataset, the dataset must be tokenised (again without padding) as the training dataset was. As one example can create several tokenised features, we generate an `overflow_to_sample_mapping`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "81413773",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pad_on_right = tokenizer.padding_side == \"right\"\n",
+    "\n",
+    "tokenized_dataset = tokenizer(\n",
+    "        dataset[\"validation\"][question_key if pad_on_right else context_key],\n",
+    "        dataset[\"validation\"][context_key if pad_on_right else question_key],\n",
+    "        truncation=\"only_second\" if pad_on_right else \"only_first\",\n",
+    "        max_length=max_seq_length,\n",
+    "        return_overflowing_tokens=True,\n",
+    "        return_offsets_mapping=True,\n",
+    "        padding=False\n",
+    "    )\n",
+    "\n",
+    "sample_mapping = tokenized_dataset.pop(\"overflow_to_sample_mapping\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f569e115",
+   "metadata": {},
+   "source": [
+    "For a generated feature in the validation dataset, the `sample_mapping` can be used to re-index the examples in the raw dataset, from which a unique value from the `id` column can be retrieved that corresponds to the tokenized feature. This id can then be added to a new column to enable identification of the corresponding target answer when classifying the model output during validation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "12d9872e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "56be4db0acb8001400a502ec\n"
+     ]
+    }
+   ],
+   "source": [
+    "tokenized_dataset[\"example_id\"] = []\n",
+    "\n",
+    "context_index = 1 if pad_on_right else 0\n",
+    "\n",
+    "# One example can give several spans, this is the index of the example containing this span of text.\n",
+    "sample_index = sample_mapping[0]\n",
+    "tokenized_dataset[\"example_id\"].append(dataset[\"validation\"][\"id\"][sample_index])\n",
+    "\n",
+    "print(tokenized_dataset[\"example_id\"][0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6478658",
+   "metadata": {},
+   "source": [
+    "Since the tokenized input contains both the `question` and `context` sections, to make it easier to determine whether an answer is correct and within the context, the `sequence_ids` can be used, as before, to set the offset mapping that is not part of the context to zero, to make classification during validation more efficient."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "84b65fd8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Before nulling 'question' part:  [(0, 0), (0, 5), (6, 9), (10, 14), (15, 26), (27, 30), (31, 34), (35, 37), (38, 43), (44, 48), (49, 51), (51, 52), (0, 0), (0, 5), (6, 10), (11, 13), (14, 17), (18, 20), (21, 29), (30, 38), (39, 43), (44, 46), (47, 56), (57, 60), (61, 69), (70, 72), (73, 76), (77, 85), (86, 94), (95, 101), (102, 103), (103, 106), (106, 107), (108, 111), (112, 115), (116, 120), (121, 127), (127, 128), (129, 132), (133, 141), (142, 150), (151, 161), (162, 163), (163, 166), (166, 167), (168, 176), (177, 183), (184, 191), (192, 200), (201, 204), (205, 213), (214, 222), (223, 233), (234, 235), (235, 238), (238, 239), (240, 248), (249, 257), (258, 266), (267, 269), (269, 270), (270, 272), (273, 275), (276, 280), (281, 286), (287, 292), (293, 298), (299, 303), (304, 309), (309, 310), (311, 314), (315, 319), (320, 323), (324, 330), (331, 333), (334, 342), (343, 344), (344, 345), (346, 350), (350, 351), (352, 354), (355, 359), (359, 360), (360, 361), (362, 369), (370, 372), (373, 376), (377, 380), (381, 390), (391, 394), (395, 399), (400, 402), (403, 408), (409, 414), (414, 415), (416, 426), (426, 427), (428, 430), (431, 435), (436, 439), (440, 443), (444, 448), (449, 454), (455, 459), (459, 460), (461, 464), (465, 471), (472, 482), (483, 486), (487, 488), (488, 494), (495, 506), (506, 507), (508, 512), (513, 520), (521, 525), (525, 526), (526, 532), (533, 544), (544, 545), (546, 548), (549, 553), (554, 556), (557, 568), (569, 576), (576, 579), (580, 583), (584, 593), (594, 596), (597, 603), (604, 608), (609, 614), (615, 619), (620, 624), (625, 629), (630, 635), (636, 638), (638, 643), (643, 644), (645, 646), (646, 651), (652, 657), (658, 661), (662, 666), (667, 672), (673, 677), (678, 682), (683, 688), (689, 691), (692, 693), (693, 698), (699, 703), (704, 705), (705, 706), (706, 707), (707, 708), (709, 711), (712, 716), (717, 720), (721, 725), (726, 731), (732, 743), (744, 751), (752, 755), (756, 762), (763, 765), (765, 770), (770, 771), (772, 774), (774, 775), (0, 0)]\n",
+      "After nulling 'question' part:  [(0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 5), (6, 10), (11, 13), (14, 17), (18, 20), (21, 29), (30, 38), (39, 43), (44, 46), (47, 56), (57, 60), (61, 69), (70, 72), (73, 76), (77, 85), (86, 94), (95, 101), (102, 103), (103, 106), (106, 107), (108, 111), (112, 115), (116, 120), (121, 127), (127, 128), (129, 132), (133, 141), (142, 150), (151, 161), (162, 163), (163, 166), (166, 167), (168, 176), (177, 183), (184, 191), (192, 200), (201, 204), (205, 213), (214, 222), (223, 233), (234, 235), (235, 238), (238, 239), (240, 248), (249, 257), (258, 266), (267, 269), (269, 270), (270, 272), (273, 275), (276, 280), (281, 286), (287, 292), (293, 298), (299, 303), (304, 309), (309, 310), (311, 314), (315, 319), (320, 323), (324, 330), (331, 333), (334, 342), (343, 344), (344, 345), (346, 350), (350, 351), (352, 354), (355, 359), (359, 360), (360, 361), (362, 369), (370, 372), (373, 376), (377, 380), (381, 390), (391, 394), (395, 399), (400, 402), (403, 408), (409, 414), (414, 415), (416, 426), (426, 427), (428, 430), (431, 435), (436, 439), (440, 443), (444, 448), (449, 454), (455, 459), (459, 460), (461, 464), (465, 471), (472, 482), (483, 486), (487, 488), (488, 494), (495, 506), (506, 507), (508, 512), (513, 520), (521, 525), (525, 526), (526, 532), (533, 544), (544, 545), (546, 548), (549, 553), (554, 556), (557, 568), (569, 576), (576, 579), (580, 583), (584, 593), (594, 596), (597, 603), (604, 608), (609, 614), (615, 619), (620, 624), (625, 629), (630, 635), (636, 638), (638, 643), (643, 644), (645, 646), (646, 651), (652, 657), (658, 661), (662, 666), (667, 672), (673, 677), (678, 682), (683, 688), (689, 691), (692, 693), (693, 698), (699, 703), (704, 705), (705, 706), (706, 707), (707, 708), (709, 711), (712, 716), (717, 720), (721, 725), (726, 731), (732, 743), (744, 751), (752, 755), (756, 762), (763, 765), (765, 770), (770, 771), (772, 774), (774, 775), (0, 0)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "sequence_ids = tokenized_dataset.sequence_ids(0)\n",
+    "\n",
+    "print(\"Before nulling 'question' part: \", tokenized_dataset[\"offset_mapping\"][0])\n",
+    "\n",
+    "tokenized_dataset[\"offset_mapping\"][0] = [\n",
+    "            (o if sequence_ids[k] == context_index else tuple((0,0)))\n",
+    "            for k, o in enumerate(tokenized_dataset[\"offset_mapping\"][0])]\n",
+    "\n",
+    "print(\"\\n After nulling 'question' part: \", tokenized_dataset[\"offset_mapping\"][0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d026adea",
+   "metadata": {},
+   "source": [
+    "Now let's put everything together in one function which will apply all of the required preprocessing and tokenisation for the training and validation segments of the dataset respectively, and generate the tokenized data for each. \n",
+    "\n",
+    "In the case of impossible answers (the answer is in another feature given by an example with a long context), we set the cls index for both the start and end position. We could also simply discard those examples from the training set if the flag `allow_impossible_answers` is `False`. Since the preprocessing is already complex enough as it is, we've kept is simple for this part."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "54c8f634",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "77c48985565e4fdf84f54a9eb35108d0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/88502 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def tokenize_squad(\n",
+    "        dataset, \n",
+    "        tokenizer, \n",
+    "        question_key:str='question', \n",
+    "        context_key:str='context', \n",
+    "        answer_key:str='answer', \n",
+    "        sequence_length:int=384, \n",
+    "        padding:bool=True, \n",
+    "        train:bool=True\n",
+    "    ):\n",
+    "\n",
+    "    # Tokenize our examples with truncation and padding, but keep the overflows using a stride. This results\n",
+    "    # in one example possible giving several features when a context is long, each of those features having a\n",
+    "    # context that overlaps a bit the context of the previous feature.\n",
+    "\n",
+    "    pad_on_right = tokenizer.padding_side == \"right\"\n",
+    "\n",
+    "    tokenized_dataset = tokenizer(\n",
+    "            dataset[question_key if pad_on_right else context_key],\n",
+    "            dataset[context_key if pad_on_right else question_key],\n",
+    "            truncation=\"only_second\" if pad_on_right else \"only_first\",\n",
+    "            max_length=sequence_length,\n",
+    "            return_overflowing_tokens=True,\n",
+    "            return_offsets_mapping=True,\n",
+    "            padding=padding\n",
+    "        )\n",
+    "\n",
+    "    sample_mapping = tokenized_dataset.pop(\"overflow_to_sample_mapping\")\n",
+    "    \n",
+    "    dataset_answers = dataset[answer_key]\n",
+    "    start_positions = []\n",
+    "    end_positions = []\n",
+    "\n",
+    "    if train:\n",
+    "        offset_mapping = tokenized_dataset.pop(\"offset_mapping\")\n",
+    "\n",
+    "        for i, offsets in enumerate(tqdm(offset_mapping)):\n",
+    "            # We will label impossible answers with the index of the CLS token.\n",
+    "            input_ids = tokenized_dataset[\"input_ids\"][i]\n",
+    "            cls_index = input_ids.index(tokenizer.cls_token_id)\n",
+    "\n",
+    "            # Grab the sequence corresponding to that example (to know what is the context and what is the question).\n",
+    "            sequence_ids = tokenized_dataset.sequence_ids(i)\n",
+    "\n",
+    "            # One example can give several spans, this is the index of the example containing this span of text.\n",
+    "            sample_index = sample_mapping[i]\n",
+    "            answers = dataset_answers[sample_index]\n",
+    "            \n",
+    "            # If no answers are given, set the cls_index as answer.\n",
+    "            if len(answers[\"answer_start\"]) == 0:\n",
+    "                start_positions.append(cls_index)\n",
+    "                end_positions.append(cls_index)\n",
+    "            else:\n",
+    "                # Start/end character index of the answer in the text.\n",
+    "                start_char = answers[\"answer_start\"][0]\n",
+    "                end_char = start_char + len(answers[\"text\"][0])\n",
+    "                # Start token index of the current span in the text.\n",
+    "                token_start_index = 0\n",
+    "                while sequence_ids[token_start_index] != (1 if pad_on_right else 0):\n",
+    "                    token_start_index += 1\n",
+    "                # End token index of the current span in the text.\n",
+    "                token_end_index = len(input_ids) - 1\n",
+    "                while sequence_ids[token_end_index] != (1 if pad_on_right else 0):\n",
+    "                    token_end_index -= 1\n",
+    "                # Detect if the answer is out of the span (in which case this feature is labeled with the CLS index).\n",
+    "                if not (\n",
+    "                    offsets[token_start_index][0] <= start_char\n",
+    "                    and offsets[token_end_index][1] >= end_char\n",
+    "                ):\n",
+    "                    start_positions.append(cls_index)\n",
+    "                    end_positions.append(cls_index)\n",
+    "                else:\n",
+    "                    # Otherwise move the token_start_index and token_end_index to the two ends of the answer.\n",
+    "                    # Note: we could go after the last offset if the answer is the last word (edge case).\n",
+    "                    while (\n",
+    "                        token_start_index < len(offsets)\n",
+    "                        and offsets[token_start_index][0] <= start_char\n",
+    "                    ):\n",
+    "                        token_start_index += 1\n",
+    "                    start_positions.append(token_start_index - 1)\n",
+    "                    while offsets[token_end_index][1] >= end_char:\n",
+    "                        token_end_index -= 1\n",
+    "                    end_positions.append(token_end_index + 1)\n",
+    "\n",
+    "        tokenized_dataset[\"start_positions\"] = start_positions\n",
+    "        tokenized_dataset[\"end_positions\"] = end_positions\n",
+    "\n",
+    "        return Dataset.from_dict(tokenized_dataset)\n",
+    "    \n",
+    "    else:\n",
+    "        # We keep the example_id that gave us this feature and we will store the offset mappings.\n",
+    "        tokenized_dataset[\"example_id\"] = []\n",
+    "        dataset_ids = dataset['id']\n",
+    "\n",
+    "        for i in range(len(tokenized_dataset[\"input_ids\"])):\n",
+    "            # Grab the sequence corresponding to that example (to know what is the context and what is the question).\n",
+    "            sequence_ids = tokenized_dataset.sequence_ids(i)\n",
+    "            context_index = 1 if pad_on_right else 0\n",
+    "\n",
+    "            # One example can give several spans, this is the index of the example containing this span of text.\n",
+    "            sample_index = sample_mapping[i]\n",
+    "            tokenized_dataset[\"example_id\"].append(dataset_ids[sample_index])\n",
+    "\n",
+    "            # Set to 0 the offset_mapping that are not part of the context so it's easy to determine if a token\n",
+    "            # position is part of the context or not.\n",
+    "            tokenized_dataset[\"offset_mapping\"][i] = [\n",
+    "                (o if sequence_ids[k] == context_index else tuple((0,0)))\n",
+    "                for k, o in enumerate(tokenized_dataset[\"offset_mapping\"][i])\n",
+    "            ]\n",
+    "\n",
+    "        return Dataset.from_dict(tokenized_dataset)\n",
+    "\n",
+    "    \n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_checkpoint, use_fast=True)\n",
+    "\n",
+    "if train:\n",
+    "    raw_train_dataset = dataset['train']\n",
+    "\n",
+    "    tokenized_training_dataset = tokenize_squad(\n",
+    "        dataset=raw_train_dataset,\n",
+    "        tokenizer=tokenizer,\n",
+    "        question_key=question_key,\n",
+    "        context_key=context_key,\n",
+    "        answer_key=answer_key,\n",
+    "        sequence_length=max_seq_length,\n",
+    "        padding=False,\n",
+    "        train=True\n",
+    "    )\n",
+    "\n",
+    "if validate:\n",
+    "    raw_validation_dataset = dataset['validation']\n",
+    "\n",
+    "    tokenized_validation_dataset = tokenize_squad(\n",
+    "        dataset=raw_validation_dataset,\n",
+    "        tokenizer=tokenizer,\n",
+    "        question_key=question_key,\n",
+    "        context_key=context_key,\n",
+    "        answer_key=answer_key,\n",
+    "        sequence_length=max_seq_length,\n",
+    "        padding=False,\n",
+    "        train=False\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f57906e8",
+   "metadata": {},
+   "source": [
+    "### 3. Packing the dataset\n",
+    "\n",
+    "Now that we have generated a dataset of tokenised features from our initial raw dataset, the next stage is to implement packing. The nature of packing requisites a slight correction to the meaning of a 'sequence' where it no longer means *one* input question/context, but rather any number of sequences (up to a given maximum number of sequences per pack) that will optimally fit into the pre-defined maximum sequence length. \n",
+    "\n",
+    "Put simply, rather than passing a heavily padded single sample into the model, the unused space in the input can be used to fit multiple sequences which are are processed by the model at the same time, leading to significant throughput benefit.\n",
+    "\n",
+    "This is fairly straightforward to do with a transformer model architecture such as BERT, which propagates each token in the input individually according to an 'extended' attention mask to account for each sequence within the input, finally reshaping the output stage to effectively treat the total number of outputs as an increased batch size. It does, however, require changes to the dataset structure and dataloading process.\n",
+    "\n",
+    "First, an optimal strategy for rearranging the sequences according to length into the best combination of 'packs' for the dataset must be developed. In order to pack efficiently, we will use an histogram-based algorithm presented in the [blog post](https://www.graphcore.ai/posts/introducing-packed-bert-for-2x-faster-training-in-natural-language-processing) https://github.com/graphcore/tutorials/tree/master/blogs_code/packedBERT. First we need to generate the histogram of the sequences lengths in our dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "17415e59",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[  0   0   0   0   0   0   0   0   0   0   1   1   2   3   9   4   7  11\n",
+      "   9   9   6  14  11  13   9   9  14   6  17   6   9   9  15  11  11  15\n",
+      "  12  12  19  29  27  35  34  49  45  53  51  56  67  93  97  92  97  95\n",
+      " 104  92 112  89 104 114 123 115  99 123 126 117 123 124 137 122 165 142\n",
+      " 154 159 156 161 159 170 167 141 154 150 136 170 165 181 166 151 156 139\n",
+      " 162 154 181 170 184 191 186 179 206 185 212 204 267 254 246 290 347 331\n",
+      " 301 379 387 448 434 505 558 532 572 613 679 649 675 715 724 749 692 697\n",
+      " 749 758 742 780 783 828 814 838 777 781 756 790 792 766 753 733 749 774\n",
+      " 769 761 744 728 730 761 735 733 730 745 706 708 725 656 688 688 677 663\n",
+      " 628 636 620 588 530 562 620 564 578 539 558 584 543 576 527 558 498 532\n",
+      " 487 529 543 483 523 483 467 514 459 447 436 383 401 408 381 369 364 381\n",
+      " 420 392 388 358 366 358 359 355 298 292 268 309 331 304 333 289 284 304\n",
+      " 242 263 289 238 257 271 291 277 264 253 239 217 261 214 251 237 212 205\n",
+      " 194 200 208 195 193 201 188 170 176 195 156 201 181 159 183 169 180 163\n",
+      " 153 171 144 139 167 156 165 145 148 156 130 122 134 137 125 125 118 115\n",
+      " 106  88 114 107 116 128 105 101  94 101  91  85  69  86  76  71  75  89\n",
+      " 112  98 106  98  89  67  87  75  68  73  81  83  69  64  55  72  67  69\n",
+      "  61  56  61  70  74  61  49  56  37  51  54  58  45  35  55  43  45  45\n",
+      "  41  36  46  54  41  41  29  27  34  39  30  42  23  36  30  39  30  30\n",
+      "  44  43  43  60  28  21  32  35  17  18  19  20  21  15  21  15  16  18\n",
+      "  14  16  14  24  14  20  20  20  24  12  11  18  16  20  19  15  17  16\n",
+      "  18  15  18  11  12 915]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 3. Generate histogram and length-ordered indices for dataset to use in the packing algorithm\n",
+    "def generate_histogram(unpadded_input_ids, max_seq_len):\n",
+    "    dataset_seq_lens:list = np.array([len(seq) for seq in unpadded_input_ids])\n",
+    "    \n",
+    "    histogram = np.zeros(max_seq_len, dtype=np.int64)\n",
+    "    seq_lens, counts = np.unique(dataset_seq_lens, return_counts=True)\n",
+    "\n",
+    "    histogram[seq_lens - 1] = counts\n",
+    "    return histogram\n",
+    "\n",
+    "if train:\n",
+    "    train_histogram = generate_histogram(tokenized_training_dataset['input_ids'], max_seq_length)\n",
+    "    print(train_histogram)\n",
+    "    \n",
+    "if validate:\n",
+    "    validation_histogram = generate_histogram(tokenized_validation_dataset['input_ids'], max_seq_length)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff5dc6fe",
+   "metadata": {},
+   "source": [
+    "Let's observe the distribution of lengths in the dataset by observing the histogram:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "03baa3eb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAh8AAAGzCAYAAACPa3XZAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8o6BhiAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA2hklEQVR4nO3de1iUdf7/8RegM54YEBQRRcRDmiK2i4eoPKQkkquZVua2m1ppFrZrbrtFJ8VqMdtrs4PaWfeQ62arlmtqnt0KXTXxkBsrhumWaKGCYuKBz+8Pf8y3EVAG4QODz8d1zZVz35+57/f7vid4zT33feNnjDECAACwxL+6CwAAAFcWwgcAALCK8AEAAKwifAAAAKsIHwAAwCrCBwAAsIrwAQAArCJ8AAAAqwgfAADAKsIHUMXWrVsnPz8/rVu3rrpLuSQ/Pz9NmDChQq8t7vP999+/5NjRo0erdevWFVoPzrv55ps1duxYa+vr27ev+vbtW6HX2tjfubm5atiwoT766KMqXQ8qB+EDbjt37tRtt92mqKgo1atXTy1atNBNN92kV155pbpLQyX67LPPNGXKFB07dqy6S/HK7t27NWXKFO3bt6+6S6l2n376qT7++GM9+uij7mlX+vYJDQ3Vfffdp6eeeqq6S0E5ED4g6fwvpG7dumn79u0aO3asXn31Vd13333y9/fXSy+9VN3loRJ99tlnSk1Nrdbw8eabbyozM9Or1+zevVupqalX7C/XH3vhhRfUv39/tWvXzj2tqrfPxx9/rI8//rhCr63I/q6I8ePH6/PPP9eaNWuqfF24PHWquwDUDM8995yCgoK0efNmBQcHe8w7fPhw9RSFWqtu3brVXYLXTp06JYfDIX//6v3MdvjwYS1dulSvvfZahZdhjNGpU6dUv379cr/G4XBUeH229vfVV1+tmJgYzZ07V/369bOyTlQMRz4gSdq7d686d+5cInhIUlhYWIlpf/3rXxUXF6f69esrJCREd955pw4cOFBi3BtvvKG2bduqfv366tGjh/71r3+V+O547ty58vPzK/GJraxzJTZt2qSBAwcqKChIDRo0UJ8+ffTpp596jJkyZYr8/PyUlZWl0aNHKzg4WEFBQRozZoxOnjxZaj89evRQgwYN1LhxY/Xu3bvEp7xly5apV69eatiwoQIDAzVo0CB98cUXJZZVXpXdxw8//KBf/epXatKkiQIDAzVkyBB988038vPz05QpU9zL++1vfytJio6Olp+fX6nbfvHixYqJiZHT6VTnzp21fPnycvdVVFSk5557Ti1btlS9evXUv39/ZWVleYwp7RyA+fPnKy4uToGBgXK5XOrSpYv7qNvcuXN1++23S5JuvPFGd90/fm/MmjVLnTt3ltPpVEREhJKTk0s9ujNz5ky1adPmou/J4vfe/Pnz9eSTT6pFixZq0KCB8vPzdeTIET3yyCPq0qWLGjVqJJfLpaSkJG3fvt1jPcXLeO+995SamqoWLVooMDBQt912m/Ly8lRYWKiJEycqLCxMjRo10pgxY1RYWHjJ7bt06VKdPXtWCQkJ7mmX2j6tW7fWz372M61YsULdunVT/fr19frrr0uS5syZo379+iksLExOp1OdOnXS7NmzS6y3rG303nvveb2/9+3bJz8/P/3hD39w/4xwOp3q3r27Nm/eXGLdCxYsUKdOnVSvXj3FxMRo0aJFZZ5HctNNN2nJkiXiD7bXbBz5gCQpKipK6enp2rVrl2JiYi469rnnntNTTz2lO+64Q/fdd5++++47vfLKK+rdu7e2bdvmDjBvv/227r//fl133XWaOHGivvrqKw0ZMkQhISGKjIysUJ1r1qxRUlKS4uLiNHnyZPn7+7t/eP7rX/9Sjx49PMbfcccdio6OVlpamj7//HO99dZbCgsL0/PPP+8ek5qaqilTpui6667T1KlT5XA4tGnTJq1Zs0YDBgyQJP3lL3/RqFGjlJiYqOeff14nT57U7NmzdcMNN2jbtm1en0xXFX2MHj1a7733nn75y1/q2muv1fr16zVo0CCP5QwbNkz//e9/9be//U0vvviimjRpIklq2rSpe8wnn3yihQsX6sEHH1RgYKBefvllDR8+XPv371doaOgle5s2bZr8/f31yCOPKC8vT9OnT9ddd92lTZs2lfmalStXauTIkerfv7+7p//85z/69NNP9etf/1q9e/fWr371K7388st6/PHHdfXVV0uS+79TpkxRamqqEhIS9MADDygzM1OzZ8/W5s2b9emnn7o/ec+ePVsTJkxQr1699PDDD2vfvn0aOnSoGjdurJYtW5ao65lnnpHD4dAjjzyiwsJCORwO7d69W4sXL9btt9+u6OhoHTp0SK+//rr69Omj3bt3KyIiwmMZaWlpql+/vh577DFlZWXplVdeUd26deXv76+jR49qypQp2rhxo+bOnavo6Gg9/fTTF92+n332mUJDQxUVFeWedqntI0mZmZkaOXKk7r//fo0dO1YdOnRwb5POnTtryJAhqlOnjpYsWaIHH3xQRUVFSk5OvmgtUsX2d7F58+bp+PHjuv/+++Xn56fp06dr2LBh+uqrr9z7bOnSpRoxYoS6dOmitLQ0HT16VPfee69atGhR6jLj4uL04osv6osvvrjkzzJUIwMYYz7++GMTEBBgAgICTHx8vPnd735nVqxYYU6fPu0xbt++fSYgIMA899xzHtN37txp6tSp455++vRpExYWZq655hpTWFjoHvfGG28YSaZPnz7uaXPmzDGSTHZ2tscy165daySZtWvXGmOMKSoqMu3btzeJiYmmqKjIPe7kyZMmOjra3HTTTe5pkydPNpLMPffc47HMW2+91YSGhrqf79mzx/j7+5tbb73VnDt3zmNs8TqOHz9ugoODzdixYz3m5+TkmKCgoBLTL2Sjj61btxpJZuLEiR7jRo8ebSSZyZMnu6e98MILpW5vY4yRZBwOh8nKynJP2759u5FkXnnllXL1efXVV3vs85deeslIMjt37nRPGzVqlImKinI///Wvf21cLpc5e/ZsmctfsGCBx3YsdvjwYeNwOMyAAQM89uGrr75qJJl33nnHGGNMYWGhCQ0NNd27dzdnzpxxj5s7d26J92RxL23atDEnT570WN+pU6dKvFeys7ON0+k0U6dOLbGMmJgYj/+PRo4cafz8/ExSUpLHMuLj4z22SVluuOEGExcXV2J6WdvHGGOioqKMJLN8+fIS8y7szxhjEhMTTZs2bTym9enTp9RtVJH9nZ2dbSSZ0NBQc+TIEff0Dz74wEgyS5YscU/r0qWLadmypTl+/Lh72rp164ykUrfXZ599ZiSZv//97yXmoebgaxdIOn+oMj09XUOGDNH27ds1ffp0JSYmqkWLFvrwww/d4xYuXKiioiLdcccd+v77792P8PBwtW/fXmvXrpUkbdmyRYcPH9b48eM9visePXq0goKCKlRjRkaG9uzZo5///OfKzc11r7ugoED9+/fXhg0bVFRU5PGa8ePHezzv1auXcnNzlZ+fL+n81wtFRUV6+umnS3yX7+fnJ+n8p/Jjx45p5MiRHj0HBASoZ8+e7p6rs4/ir0UefPBBj3EPPfSQV7VJUkJCgtq2bet+HhsbK5fLpa+++qpcrx8zZozHPu/Vq5ckXfT1wcHBKigo0MqVK72ud9WqVTp9+rQmTpzosQ/Hjh0rl8ulpUuXSjr/nszNzdXYsWNVp87/HfS966671Lhx41KXPWrUqBLnRTidTvd6zp07p9zcXDVq1EgdOnTQ559/XmIZd999t8c5Dz179pQxRvfcc4/HuJ49e+rAgQM6e/bsRfvNzc0ts96LiY6OVmJiYonpP+4vLy9P33//vfr06aOvvvpKeXl5l1xuRfZ3sREjRnj0cuFrv/32W+3cuVN33323GjVq5B7Xp08fdenSpdRlFi/v+++/v+T6UX342gVu3bt318KFC3X69Glt375dixYt0osvvqjbbrtNGRkZ6tSpk/bs2SNjjNq3b1/qMop/yH799deSVGJc3bp11aZNmwrVt2fPHknnfyGUJS8vz+OHWatWrTzmF887evSoXC6X9u7dK39/f3Xq1OmS6y3rBDaXy1W+Bi5YXmX28fXXX8vf31/R0dEe4358NUR5Xbiu4vUdPXq0Qq//ca1lefDBB/Xee+8pKSlJLVq00IABA3THHXdo4MCBl1xf8Xut+GuEYg6HQ23atHHPL/7vhdukTp06ZX5tduH2lM6f0/LSSy9p1qxZys7O1rlz59zzSvta6sLtURy+L/zqMSgoSEVFRcrLy7vk11umAuczlNaLdP6y3cmTJys9Pb3EeUR5eXmX/LBQkf1d3teWtc+Kp5UW9oq3TfGHB9RMhA+U4HA41L17d3Xv3l1XXXWVxowZowULFmjy5MkqKiqSn5+fli1bpoCAgBKv/fGnk/Iq64fEj3+oS3IfDXjhhRd0zTXXlPqaC9dfWo2Sdz+8i9f7l7/8ReHh4SXm//hTtDfLs91HeV3uuiry+rCwMGVkZGjFihVatmyZli1bpjlz5ujuu+/Wn/70p3KttyqUdjXI73//ez311FO655579MwzzygkJET+/v6aOHFiiSNWUtnbo6LbOTQ0tNxB8MdK62Xv3r3q37+/OnbsqD/+8Y+KjIyUw+HQRx99pBdffLHUfi50Oe+XqnhfF2+b4vOZUDMRPnBR3bp1kyQdPHhQktS2bVsZYxQdHa2rrrqqzNcVnwy3Z88ejyMGZ86cUXZ2trp27eqeVvxp58IrE4o/9RQr/irA5XJ5nOl/Odq2bauioiLt3r27zCBQvN6wsLBKWW9V9BEVFaWioiJlZ2d7HG268KoDqeZ+InQ4HBo8eLAGDx6soqIiPfjgg3r99df11FNPqV27dmXWXfxey8zM9Diqdvr0aWVnZ7u3cfG4rKws3Xjjje5xZ8+e1b59+xQbG1uuOt9//33deOONevvttz2mHzt2zMovvI4dO+of//hHiekV2a9LlixRYWGhPvzwQ4+jEN5+lVhVfrzPLlTaNEnKzs6W5HmyLWoezvmApPM/bEr7tFF8q+LiQ9rDhg1TQECAUlNTS4w3xig3N1fS+dDStGlTvfbaazp9+rR7zNy5c0uEjOJfxhs2bHBPO3funN544w2PcXFxcWrbtq3+8Ic/6MSJEyVq/e6778rbrtvQoUPl7++vqVOnlviUV9xfYmKiXC6Xfv/73+vMmTOXvd6q6KP4u/xZs2Z5TC/t7rQNGzaUVDLsVafi900xf39/dxgovvy0rLoTEhLkcDj08ssve7wn3377beXl5bmv+OnWrZtCQ0P15ptvepxX8e6773p1JCEgIKDEe3/BggX65ptvyr2MyxEfH6+jR4+WOKeiIvu1+MjDj/vJy8vTnDlzLr/QShAREaGYmBj9+c9/9vh/Zf369dq5c2epr9m6dauCgoLUuXNnW2WiAjjyAUnnT0w8efKkbr31VnXs2FGnT5/WZ599pr///e9q3bq1xowZI+l8UHj22WeVkpLivkwxMDBQ2dnZWrRokcaNG6dHHnlEdevW1bPPPqv7779f/fr104gRI5Sdna05c+aUOOejc+fOuvbaa5WSkqIjR44oJCRE8+fPL3Hinb+/v9566y0lJSWpc+fOGjNmjFq0aKFvvvlGa9eulcvl0pIlS7zqu127dnriiSf0zDPPqFevXho2bJicTqc2b96siIgIpaWlyeVyafbs2frlL3+pn/70p7rzzjvVtGlT7d+/X0uXLtX111+vV199tdzrrIo+4uLiNHz4cM2YMUO5ubnuS23/+9//SvL8VBwXFydJeuKJJ3TnnXeqbt26Gjx4sPuXV3W47777dOTIEfXr108tW7bU119/rVdeeUXXXHON+xPsNddco4CAAD3//PPKy8uT0+l0358iJSVFqampGjhwoIYMGaLMzEzNmjVL3bt31y9+8QtJ54+sTJkyRQ899JD69eunO+64Q/v27dPcuXPVtm3bch85+NnPfqapU6dqzJgxuu6667Rz5069++67FT6XyVuDBg1SnTp1tGrVKo0bN849/WLbpywDBgxwH3G6//77deLECb355psKCwtzH+2sbr///e91yy236Prrr9eYMWN09OhRvfrqq4qJiSk1vK9cuVKDBw+usUf48P9ZvroGNdSyZcvMPffcYzp27GgaNWpkHA6HadeunXnooYfMoUOHSoz/xz/+YW644QbTsGFD07BhQ9OxY0eTnJxsMjMzPcbNmjXLREdHG6fTabp162Y2bNhQ4pI9Y4zZu3evSUhIME6n0zRr1sw8/vjjZuXKlaVeOrht2zYzbNgwExoaapxOp4mKijJ33HGHWb16tXtM8SWq3333ncdry7qs95133jE/+clPjNPpNI0bNzZ9+vQxK1eu9Bizdu1ak5iYaIKCgky9evVM27ZtzejRo82WLVsuum0vvNS2qvooKCgwycnJJiQkxDRq1MgMHTrUZGZmGklm2rRpHq9/5plnTIsWLYy/v7/HciSZ5OTkEj1ERUWZUaNGlavPBQsWeEwvvqxyzpw57mkXXnr5/vvvmwEDBpiwsDDjcDhMq1atzP33328OHjzosaw333zTtGnTxgQEBJTYpq+++qrp2LGjqVu3rmnWrJl54IEHzNGjR0vU+fLLL5uoqCjjdDpNjx49zKeffmri4uLMwIEDL9mLMecvtf3Nb35jmjdvburXr2+uv/56k56eXualqBcuo3jfbd682WN6Wfu6NEOGDDH9+/cvMb2s7RMVFWUGDRpU6rI+/PBDExsba+rVq2dat25tnn/+efPOO++UeH+Vt7/y7O/iMS+88EKJenTBpeHGGDN//nzTsWNH43Q6TUxMjPnwww/N8OHDTceOHT3G/ec//zGSzKpVq0rtFTWHnzHcBg52Fd8l0Rf+yquvy8jI0E9+8hP99a9/1V133VXd5dRIRUVFatq0qYYNG6Y333yzusspl+K7sn755ZdlXnlW211zzTVq2rSpx+XZEydO1IYNG7R161aOfNRwnPMB1BI//PBDiWkzZsyQv7+/evfuXQ0V1TynTp0qcb7Gn//8Zx05cqTCfy6+OvTq1UsDBgzQ9OnTq7uUKnfmzJkSX8GuW7dO27dv99hnubm5euutt/Tss88SPHwA53wAtcT06dO1detW3XjjjapTp477ktVx48ZV+Hb2tc3GjRv18MMP6/bbb1doaKg+//xzvf3224qJiXH/bRRfsWzZsuouwYpvvvlGCQkJ+sUvfqGIiAh9+eWXeu211xQeHu5x873Q0NBSzwFBzUT4AGqJ6667TitXrtQzzzyjEydOqFWrVpoyZYqeeOKJ6i6txmjdurUiIyP18ssvu09uvvvuuzVt2rTL+qutqDqNGzdWXFyc3nrrLX333Xdq2LChBg0apGnTppXrbw2hZuKcDwAAYBXnfAAAAKsIHwAAwKoad85HUVGRvv32WwUGBnLGMgAAPsIYo+PHjysiIqLEXwm/UI0LH99++y1n5gMA4KMOHDigli1bXnRMjQsfgYGBks4X7+2fKgcAANUjPz9fkZGR7t/jF1PjwkfxVy0ul4vwAQCAjynPKROccAoAAKwifAAAAKsIHwAAwCrCBwAAsIrwAQAArCJ8AAAAqwgfAADAKsIHAACwivABAACsInwAAACrCB8AAMAqwgcAALCK8AEAAKwifAAAAKvqVHcBNV3rx5Z6NX7ftEFVVAkAALUDRz4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGCVV+Fj9uzZio2NlcvlksvlUnx8vJYtW+ae37dvX/n5+Xk8xo8fX+lFAwAA31XHm8EtW7bUtGnT1L59exlj9Kc//Um33HKLtm3bps6dO0uSxo4dq6lTp7pf06BBg8qtGAAA+DSvwsfgwYM9nj/33HOaPXu2Nm7c6A4fDRo0UHh4eOVVCAAAapUKn/Nx7tw5zZ8/XwUFBYqPj3dPf/fdd9WkSRPFxMQoJSVFJ0+evOhyCgsLlZ+f7/EAAAC1l1dHPiRp586dio+P16lTp9SoUSMtWrRInTp1kiT9/Oc/V1RUlCIiIrRjxw49+uijyszM1MKFC8tcXlpamlJTUyveAQAA8Cl+xhjjzQtOnz6t/fv3Ky8vT++//77eeustrV+/3h1AfmzNmjXq37+/srKy1LZt21KXV1hYqMLCQvfz/Px8RUZGKi8vTy6Xy8t2Kl/rx5Z6NX7ftEFVVAkAADVXfn6+goKCyvX72+sjHw6HQ+3atZMkxcXFafPmzXrppZf0+uuvlxjbs2dPSbpo+HA6nXI6nd6WAQAAfNRl3+ejqKjI48jFj2VkZEiSmjdvfrmrAQAAtYRXRz5SUlKUlJSkVq1a6fjx45o3b57WrVunFStWaO/evZo3b55uvvlmhYaGaseOHXr44YfVu3dvxcbGVlX9AADAx3gVPg4fPqy7775bBw8eVFBQkGJjY7VixQrddNNNOnDggFatWqUZM2aooKBAkZGRGj58uJ588smqqh0AAPggr8LH22+/Xea8yMhIrV+//rILAgAAtRt/2wUAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFjlVfiYPXu2YmNj5XK55HK5FB8fr2XLlrnnnzp1SsnJyQoNDVWjRo00fPhwHTp0qNKLBgAAvsur8NGyZUtNmzZNW7du1ZYtW9SvXz/dcsst+uKLLyRJDz/8sJYsWaIFCxZo/fr1+vbbbzVs2LAqKRwAAPgmP2OMuZwFhISE6IUXXtBtt92mpk2bat68ebrtttskSV9++aWuvvpqpaen69prry3X8vLz8xUUFKS8vDy5XK7LKa1StH5sqVfj900bVEWVAABQc3nz+7vC53ycO3dO8+fPV0FBgeLj47V161adOXNGCQkJ7jEdO3ZUq1atlJ6eXuZyCgsLlZ+f7/EAAAC1l9fhY+fOnWrUqJGcTqfGjx+vRYsWqVOnTsrJyZHD4VBwcLDH+GbNmiknJ6fM5aWlpSkoKMj9iIyM9LoJAADgO7wOHx06dFBGRoY2bdqkBx54QKNGjdLu3bsrXEBKSory8vLcjwMHDlR4WQAAoOar4+0LHA6H2rVrJ0mKi4vT5s2b9dJLL2nEiBE6ffq0jh075nH049ChQwoPDy9zeU6nU06n0/vKAQCAT7rs+3wUFRWpsLBQcXFxqlu3rlavXu2el5mZqf379ys+Pv5yVwMAAGoJr458pKSkKCkpSa1atdLx48c1b948rVu3TitWrFBQUJDuvfdeTZo0SSEhIXK5XHrooYcUHx9f7itdAABA7edV+Dh8+LDuvvtuHTx4UEFBQYqNjdWKFSt00003SZJefPFF+fv7a/jw4SosLFRiYqJmzZpVJYUDAADfdNn3+ahs3OcDAADfY+U+HwAAABVB+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVXWquwDbWj+2tLpLAADgisaRDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABglVfhIy0tTd27d1dgYKDCwsI0dOhQZWZmeozp27ev/Pz8PB7jx4+v1KIBAIDv8ip8rF+/XsnJydq4caNWrlypM2fOaMCAASooKPAYN3bsWB08eND9mD59eqUWDQAAfJdX9/lYvny5x/O5c+cqLCxMW7duVe/evd3TGzRooPDw8HIts7CwUIWFhe7n+fn53pQEAAB8zGWd85GXlydJCgkJ8Zj+7rvvqkmTJoqJiVFKSopOnjxZ5jLS0tIUFBTkfkRGRl5OSQAAoIbzM8aYirywqKhIQ4YM0bFjx/TJJ5+4p7/xxhuKiopSRESEduzYoUcffVQ9evTQwoULS11OaUc+IiMjlZeXJ5fLVZHSLqqq73C6b9qgKl0+AAA1UX5+voKCgsr1+7vCt1dPTk7Wrl27PIKHJI0bN8797y5duqh58+bq37+/9u7dq7Zt25ZYjtPplNPprGgZAADAx1Toa5cJEybon//8p9auXauWLVtedGzPnj0lSVlZWRVZFQAAqGW8OvJhjNFDDz2kRYsWad26dYqOjr7kazIyMiRJzZs3r1CBAACgdvEqfCQnJ2vevHn64IMPFBgYqJycHElSUFCQ6tevr71792revHm6+eabFRoaqh07dujhhx9W7969FRsbWyUNAAAA3+JV+Jg9e7ak8zcS+7E5c+Zo9OjRcjgcWrVqlWbMmKGCggJFRkZq+PDhevLJJyutYAAA4Nu8/trlYiIjI7V+/frLKggAANRu/G0XAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVV6Fj7S0NHXv3l2BgYEKCwvT0KFDlZmZ6THm1KlTSk5OVmhoqBo1aqThw4fr0KFDlVo0AADwXV6Fj/Xr1ys5OVkbN27UypUrdebMGQ0YMEAFBQXuMQ8//LCWLFmiBQsWaP369fr22281bNiwSi8cAAD4pjreDF6+fLnH87lz5yosLExbt25V7969lZeXp7ffflvz5s1Tv379JElz5szR1VdfrY0bN+raa6+tvMoBAIBPuqxzPvLy8iRJISEhkqStW7fqzJkzSkhIcI/p2LGjWrVqpfT09FKXUVhYqPz8fI8HAACovSocPoqKijRx4kRdf/31iomJkSTl5OTI4XAoODjYY2yzZs2Uk5NT6nLS0tIUFBTkfkRGRla0JAAA4AMqHD6Sk5O1a9cuzZ8//7IKSElJUV5envtx4MCBy1oeAACo2bw656PYhAkT9M9//lMbNmxQy5Yt3dPDw8N1+vRpHTt2zOPox6FDhxQeHl7qspxOp5xOZ0XKAAAAPsirIx/GGE2YMEGLFi3SmjVrFB0d7TE/Li5OdevW1erVq93TMjMztX//fsXHx1dOxQAAwKd5deQjOTlZ8+bN0wcffKDAwED3eRxBQUGqX7++goKCdO+992rSpEkKCQmRy+XSQw89pPj4eK50AQAAkrwMH7Nnz5Yk9e3b12P6nDlzNHr0aEnSiy++KH9/fw0fPlyFhYVKTEzUrFmzKqVYAADg+7wKH8aYS46pV6+eZs6cqZkzZ1a4KAAAUHvxt10AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWFWnuguobVo/trTcY/dNG1SFlQAAUDNx5AMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWOV1+NiwYYMGDx6siIgI+fn5afHixR7zR48eLT8/P4/HwIEDK6teAADg47wOHwUFBeratatmzpxZ5piBAwfq4MGD7sff/va3yyoSAADUHl7f5yMpKUlJSUkXHeN0OhUeHl7hogAAQO1VJed8rFu3TmFhYerQoYMeeOAB5ebmljm2sLBQ+fn5Hg8AAFB7VfodTgcOHKhhw4YpOjpae/fu1eOPP66kpCSlp6crICCgxPi0tDSlpqZWdhk+wZu7oVYEd1AFANRElR4+7rzzTve/u3TpotjYWLVt21br1q1T//79S4xPSUnRpEmT3M/z8/MVGRlZ2WUBAIAaosovtW3Tpo2aNGmirKysUuc7nU65XC6PBwAAqL2qPHz873//U25urpo3b17VqwIAAD7A669dTpw44XEUIzs7WxkZGQoJCVFISIhSU1M1fPhwhYeHa+/evfrd736ndu3aKTExsVILBwAAvsnr8LFlyxbdeOON7ufF52uMGjVKs2fP1o4dO/SnP/1Jx44dU0REhAYMGKBnnnlGTqez8qoGAAA+y+vw0bdvXxljypy/YsWKyyoIAADUbvxtFwAAYBXhAwAAWFXp9/kAUPW8vUEdN5wDUJNw5AMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVtWp7gJQc7R+bKlX4/dNG1RFlQAAajOOfAAAAKsIHwAAwCrCBwAAsIrwAQAArCJ8AAAAqwgfAADAKsIHAACwivABAACsInwAAACruMNpLebtHUtrGu64CgC1E0c+AACAVYQPAABgFeEDAABYRfgAAABWeR0+NmzYoMGDBysiIkJ+fn5avHixx3xjjJ5++mk1b95c9evXV0JCgvbs2VNZ9QIAAB/ndfgoKChQ165dNXPmzFLnT58+XS+//LJee+01bdq0SQ0bNlRiYqJOnTp12cUCAADf5/WltklJSUpKSip1njFGM2bM0JNPPqlbbrlFkvTnP/9ZzZo10+LFi3XnnXdeXrUAAMDnVeo5H9nZ2crJyVFCQoJ7WlBQkHr27Kn09PRSX1NYWKj8/HyPBwAAqL0q9SZjOTk5kqRmzZp5TG/WrJl73oXS0tKUmppamWUAlc7Xb3jm6/UDqF2q/WqXlJQU5eXluR8HDhyo7pIAAEAVqtTwER4eLkk6dOiQx/RDhw65513I6XTK5XJ5PAAAQO1VqeEjOjpa4eHhWr16tXtafn6+Nm3apPj4+MpcFQAA8FFen/Nx4sQJZWVluZ9nZ2crIyNDISEhatWqlSZOnKhnn31W7du3V3R0tJ566ilFRERo6NChlVk3AADwUV6Hjy1btujGG290P580aZIkadSoUZo7d65+97vfqaCgQOPGjdOxY8d0ww03aPny5apXr17lVQ0AAHyW1+Gjb9++MsaUOd/Pz09Tp07V1KlTL6swAABQO1X71S4AAODKQvgAAABWET4AAIBVlXqHU+BivL3LZlWqSbX4Ou6eCsBbHPkAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWMVNxlBhNe1GXTWtHgBA6TjyAQAArCJ8AAAAqwgfAADAKsIHAACwivABAACsInwAAACrCB8AAMAqwgcAALCK8AEAAKziDqdAFfD2bqv7pg2qokoqpibdLdbXtyWAkjjyAQAArCJ8AAAAqwgfAADAKsIHAACwivABAACsInwAAACrCB8AAMAqwgcAALCK8AEAAKwifAAAAKsIHwAAwCrCBwAAsIrwAQAArCJ8AAAAqyo9fEyZMkV+fn4ej44dO1b2agAAgI+qUxUL7dy5s1atWvV/K6lTJasBAAA+qEpSQZ06dRQeHl4ViwYAAD6uSs752LNnjyIiItSmTRvddddd2r9/f5ljCwsLlZ+f7/EAAAC1l58xxlTmApctW6YTJ06oQ4cOOnjwoFJTU/XNN99o165dCgwMLDF+ypQpSk1NLTE9Ly9PLperMkuTJLV+bGmlLxNAzbFv2qDqLsEab3+eXUnbBvbl5+crKCioXL+/K/3IR1JSkm6//XbFxsYqMTFRH330kY4dO6b33nuv1PEpKSnKy8tzPw4cOFDZJQEAgBqkys8EDQ4O1lVXXaWsrKxS5zudTjmdzqouAwAA1BBVfp+PEydOaO/evWrevHlVrwoAAPiASg8fjzzyiNavX699+/bps88+06233qqAgACNHDmyslcFAAB8UKV/7fK///1PI0eOVG5urpo2baobbrhBGzduVNOmTSt7VQAAwAdVeviYP39+ZS8SAADUIvxtFwAAYBXhAwAAWMUfXQFQq/j6jbd8+UaIVV17TdtX3vD192Vl48gHAACwivABAACsInwAAACrCB8AAMAqwgcAALCK8AEAAKwifAAAAKsIHwAAwCrCBwAAsIo7nAKAF66kO1X68t1WvVXT9mtNq6eyceQDAABYRfgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBU3GQOAKlSTbtRVk2rBlY0jHwAAwCrCBwAAsIrwAQAArCJ8AAAAqwgfAADAKsIHAACwivABAACsInwAAACrCB8AAMAq7nAKAICXatrdYr2tZ9+0QVVUSflw5AMAAFhF+AAAAFYRPgAAgFWEDwAAYFWVhY+ZM2eqdevWqlevnnr27Kl///vfVbUqAADgQ6okfPz973/XpEmTNHnyZH3++efq2rWrEhMTdfjw4apYHQAA8CFVEj7++Mc/auzYsRozZow6deqk1157TQ0aNNA777xTFasDAAA+pNLv83H69Glt3bpVKSkp7mn+/v5KSEhQenp6ifGFhYUqLCx0P8/Ly5Mk5efnV3ZpkqSiwpNVslwAvsnbnzX8DKk+VfV7Qbry9mtVbMviZRpjLjm20sPH999/r3PnzqlZs2Ye05s1a6Yvv/yyxPi0tDSlpqaWmB4ZGVnZpQFACUEzqrsClBf7qvJU5bY8fvy4goKCLjqm2u9wmpKSokmTJrmfFxUV6ciRIwoNDZWfn1+lris/P1+RkZE6cOCAXC5XpS67prmSepWurH7ptfa6kvql19rHGKPjx48rIiLikmMrPXw0adJEAQEBOnTokMf0Q4cOKTw8vMR4p9Mpp9PpMS04OLiyy/Lgcrlq9Rvgx66kXqUrq196rb2upH7ptXa51BGPYpV+wqnD4VBcXJxWr17tnlZUVKTVq1crPj6+slcHAAB8TJV87TJp0iSNGjVK3bp1U48ePTRjxgwVFBRozJgxVbE6AADgQ6okfIwYMULfffednn76aeXk5Oiaa67R8uXLS5yEapvT6dTkyZNLfM1TG11JvUpXVr/0WntdSf3S65XNz5TnmhgAAIBKwt92AQAAVhE+AACAVYQPAABgFeEDAABYRfgAAABWXTHhY+bMmWrdurXq1aunnj176t///nd1l1QppkyZIj8/P49Hx44d3fNPnTql5ORkhYaGqlGjRho+fHiJu8/WVBs2bNDgwYMVEREhPz8/LV682GO+MUZPP/20mjdvrvr16yshIUF79uzxGHPkyBHdddddcrlcCg4O1r333qsTJ05Y7KJ8LtXr6NGjS+zngQMHeozxlV7T0tLUvXt3BQYGKiwsTEOHDlVmZqbHmPK8b/fv369BgwapQYMGCgsL029/+1udPXvWZiuXVJ5e+/btW2Lfjh8/3mOML/QqSbNnz1ZsbKz7Tp7x8fFatmyZe35t2a/SpXutTfu1SpgrwPz5843D4TDvvPOO+eKLL8zYsWNNcHCwOXToUHWXdtkmT55sOnfubA4ePOh+fPfdd+7548ePN5GRkWb16tVmy5Yt5tprrzXXXXddNVZcfh999JF54oknzMKFC40ks2jRIo/506ZNM0FBQWbx4sVm+/btZsiQISY6Otr88MMP7jEDBw40Xbt2NRs3bjT/+te/TLt27czIkSMtd3Jpl+p11KhRZuDAgR77+ciRIx5jfKXXxMREM2fOHLNr1y6TkZFhbr75ZtOqVStz4sQJ95hLvW/Pnj1rYmJiTEJCgtm2bZv56KOPTJMmTUxKSkp1tFSm8vTap08fM3bsWI99m5eX557vK70aY8yHH35oli5dav773/+azMxM8/jjj5u6deuaXbt2GWNqz3415tK91qb9WhWuiPDRo0cPk5yc7H5+7tw5ExERYdLS0qqxqsoxefJk07Vr11LnHTt2zNStW9csWLDAPe0///mPkWTS09MtVVg5LvyFXFRUZMLDw80LL7zgnnbs2DHjdDrN3/72N2OMMbt37zaSzObNm91jli1bZvz8/Mw333xjrXZvlRU+brnlljJf46u9GmPM4cOHjSSzfv16Y0z53rcfffSR8ff3Nzk5Oe4xs2fPNi6XyxQWFtptwAsX9mrM+V9Sv/71r8t8ja/2Wqxx48bmrbfeqtX7tVhxr8bU/v16uWr91y6nT5/W1q1blZCQ4J7m7++vhIQEpaenV2NllWfPnj2KiIhQmzZtdNddd2n//v2SpK1bt+rMmTMevXfs2FGtWrXy+d6zs7OVk5Pj0VtQUJB69uzp7i09PV3BwcHq1q2be0xCQoL8/f21adMm6zVfrnXr1iksLEwdOnTQAw88oNzcXPc8X+41Ly9PkhQSEiKpfO/b9PR0denSxeOuyYmJicrPz9cXX3xhsXrvXNhrsXfffVdNmjRRTEyMUlJSdPLkSfc8X+313Llzmj9/vgoKChQfH1+r9+uFvRarjfu1slTJ7dVrku+//17nzp0rcWv3Zs2a6csvv6ymqipPz549NXfuXHXo0EEHDx5UamqqevXqpV27diknJ0cOh6PEXwlu1qyZcnJyqqfgSlJcf2n7tXheTk6OwsLCPObXqVNHISEhPtf/wIEDNWzYMEVHR2vv3r16/PHHlZSUpPT0dAUEBPhsr0VFRZo4caKuv/56xcTESFK53rc5OTml7vvieTVRab1K0s9//nNFRUUpIiJCO3bs0KOPPqrMzEwtXLhQku/1unPnTsXHx+vUqVNq1KiRFi1apE6dOikjI6PW7deyepVq336tbLU+fNR2SUlJ7n/HxsaqZ8+eioqK0nvvvaf69etXY2WoTHfeeaf73126dFFsbKzatm2rdevWqX///tVY2eVJTk7Wrl279Mknn1R3KVWurF7HjRvn/neXLl3UvHlz9e/fX3v37lXbtm1tl3nZOnTooIyMDOXl5en999/XqFGjtH79+uouq0qU1WunTp1q3X6tbLX+a5cmTZooICCgxBnVhw4dUnh4eDVVVXWCg4N11VVXKSsrS+Hh4Tp9+rSOHTvmMaY29F5c/8X2a3h4uA4fPuwx/+zZszpy5IjP99+mTRs1adJEWVlZknyz1wkTJuif//yn1q5dq5YtW7qnl+d9Gx4eXuq+L55X05TVa2l69uwpSR771pd6dTgcateuneLi4pSWlqauXbvqpZdeqpX7taxeS+Pr+7Wy1frw4XA4FBcXp9WrV7unFRUVafXq1R7fzdUWJ06c0N69e9W8eXPFxcWpbt26Hr1nZmZq//79Pt97dHS0wsPDPXrLz8/Xpk2b3L3Fx8fr2LFj2rp1q3vMmjVrVFRU5P5B4Kv+97//KTc3V82bN5fkW70aYzRhwgQtWrRIa9asUXR0tMf88rxv4+PjtXPnTo/AtXLlSrlcLvdh75rgUr2WJiMjQ5I89q0v9FqWoqIiFRYW1qr9WpbiXktT2/brZavuM15tmD9/vnE6nWbu3Llm9+7dZty4cSY4ONjjLGNf9Zvf/MasW7fOZGdnm08//dQkJCSYJk2amMOHDxtjzl/a1qpVK7NmzRqzZcsWEx8fb+Lj46u56vI5fvy42bZtm9m2bZuRZP74xz+abdu2ma+//toYc/5S2+DgYPPBBx+YHTt2mFtuuaXUS21/8pOfmE2bNplPPvnEtG/fvkZefnqxXo8fP24eeeQRk56ebrKzs82qVavMT3/6U9O+fXtz6tQp9zJ8pdcHHnjABAUFmXXr1nlchnjy5En3mEu9b4svUxwwYIDJyMgwy5cvN02bNq1xlyleqtesrCwzdepUs2XLFpOdnW0++OAD06ZNG9O7d2/3MnylV2OMeeyxx8z69etNdna22bFjh3nssceMn5+f+fjjj40xtWe/GnPxXmvbfq0KV0T4MMaYV155xbRq1co4HA7To0cPs3HjxuouqVKMGDHCNG/e3DgcDtOiRQszYsQIk5WV5Z7/ww8/mAcffNA0btzYNGjQwNx6663m4MGD1Vhx+a1du9ZIKvEYNWqUMeb85bZPPfWUadasmXE6naZ///4mMzPTYxm5ublm5MiRplGjRsblcpkxY8aY48ePV0M3F3exXk+ePGkGDBhgmjZtaurWrWuioqLM2LFjS4RnX+m1tD4lmTlz5rjHlOd9u2/fPpOUlGTq169vmjRpYn7zm9+YM2fOWO7m4i7V6/79+03v3r1NSEiIcTqdpl27dua3v/2tx/0gjPGNXo0x5p577jFRUVHG4XCYpk2bmv79+7uDhzG1Z78ac/Fea9t+rQp+xhhj7zgLAAC40tX6cz4AAEDNQvgAAABWET4AAIBVhA8AAGAV4QMAAFhF+AAAAFYRPgAAgFWEDwAAYBXhAwAAWEX4AAAAVhE+AACAVf8POYJm+xookycAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "plt.hist(train_histogram, bins = [k for k in range(0,max_seq_length,10)]) \n",
+    "plt.title(\"Sequence length histogram (training)\") \n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "720ea314",
+   "metadata": {},
+   "source": [
+    "The histogram shows the benefits of packing the dataset, a significant majority of samples are short enough to be packed into a single sequence length. The majority of sequences being less than half of the maximum sequence length indicates a throughput benefit to be obtained from packing.\n",
+    "\n",
+    "Next, we apply the 'shortest pack first' histogram packing algorithm to generate a packing strategy using the histogram."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "84743211",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Packing efficiency (fraction of real tokens): 98.0634\n",
+      " Speed-up theoretical limit: 2.2661\n",
+      " Achieved speed-up over un-packed dataset: 2.22222\n",
+      " Runtime: Packed 88502 sequences in 0.009 seconds\n",
+      " Average packing factor: 2.222216642394416\n",
+      "Training: mean sequences per pack 2.222216642394416\n",
+      "Packing efficiency (fraction of real tokens): 97.7304\n",
+      " Speed-up theoretical limit: 2.2093\n",
+      " Achieved speed-up over un-packed dataset: 2.15917\n",
+      " Runtime: Packed 10757 sequences in 0.008 seconds\n",
+      " Average packing factor: 2.1591730228823764\n",
+      "Validation: mean sequences per pack 2.1591730228823764\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 4. Run the shortest pack first histogram packing algorithm\n",
+    "\n",
+    "from scipy import optimize, stats\n",
+    "from collections import defaultdict\n",
+    "\n",
+    "def add_pack(pack, count, tmp, final, limit, offset, max_sequence_length=512):\n",
+    "    \"\"\"Filter out packs that reached maximum length or number of components.\"\"\"\n",
+    "    if len(pack) == limit or offset == 0:\n",
+    "        final[offset].append((count, pack))\n",
+    "    else:\n",
+    "        tmp[offset].append((count, pack))\n",
+    "\n",
+    "def shortest_pack_first_histogram_packing(\n",
+    "    histogram,\n",
+    "    max_sequence_length,\n",
+    "    max_sequences_per_pack\n",
+    "):\n",
+    "    \"\"\"Shortest-pack-first histogram-packing.\"\"\"\n",
+    "\n",
+    "    start = time.time()\n",
+    "    reversed_histogram = np.flip(histogram)\n",
+    "    # Initialize main strategy data dictionary.\n",
+    "    # The key indicates how many tokens are left for full length.\n",
+    "    # The value is a list of tuples, consisting of counts and respective packs.\n",
+    "    # A pack is a (sorted) list of sequence length values that get concatenated.\n",
+    "    tmp_strategies_per_length = defaultdict(list)\n",
+    "    strategies_per_length = defaultdict(list)\n",
+    "    # Index i indicates here, how much space is left, due to reversed histogram\n",
+    "    for i in range(max_sequence_length):\n",
+    "        n_sequences_to_bin = reversed_histogram[i]\n",
+    "        length_to_bin = max_sequence_length - i\n",
+    "        offset = i + 1  # largest possible offset\n",
+    "        while n_sequences_to_bin > 0:\n",
+    "            if (length_to_bin + offset) in tmp_strategies_per_length:\n",
+    "                # extract shortest pack that will get modified\n",
+    "                n_sequences_to_pack, pack = tmp_strategies_per_length[\n",
+    "                    length_to_bin + offset].pop()\n",
+    "                new_pack = pack + [length_to_bin]\n",
+    "                count = min(n_sequences_to_pack, n_sequences_to_bin)\n",
+    "                if n_sequences_to_pack > n_sequences_to_bin:\n",
+    "                    # old pack gets reduced\n",
+    "                    n_sequences_to_pack -= n_sequences_to_bin\n",
+    "                    tmp_strategies_per_length[length_to_bin + offset].append(\n",
+    "                        (n_sequences_to_pack, pack))\n",
+    "                    n_sequences_to_bin = 0\n",
+    "                else:\n",
+    "                    n_sequences_to_bin -= n_sequences_to_pack\n",
+    "                add_pack(new_pack, count,\n",
+    "                         tmp_strategies_per_length, strategies_per_length,\n",
+    "                         max_sequences_per_pack, offset)\n",
+    "                # clean up to speed up main key search\n",
+    "                if not tmp_strategies_per_length[length_to_bin + offset]:\n",
+    "                    tmp_strategies_per_length.pop(length_to_bin + offset)\n",
+    "            else:\n",
+    "                offset -= 1\n",
+    "            # Does not fit anywhere. Create new pack.\n",
+    "            if offset < 0:\n",
+    "                add_pack([length_to_bin], n_sequences_to_bin,\n",
+    "                         tmp_strategies_per_length, strategies_per_length,\n",
+    "                         max_sequences_per_pack, i)\n",
+    "                n_sequences_to_bin = 0\n",
+    "    # merge all strategies\n",
+    "    for key in tmp_strategies_per_length:\n",
+    "        strategies_per_length[key].extend(tmp_strategies_per_length[key])\n",
+    "    # flatten strategies dictionary\n",
+    "    strategy_set = []\n",
+    "    strategy_repeat_count = []\n",
+    "    for key in strategies_per_length:\n",
+    "        for count, pack in strategies_per_length[key]:\n",
+    "            pack.reverse()\n",
+    "            strategy_set.append(pack)\n",
+    "            strategy_repeat_count.append(count)\n",
+    "\n",
+    "    # Summarize efficiency of solution\n",
+    "    duration = time.time() - start\n",
+    "    sequence_lengths = np.arange(1, max_sequence_length + 1)\n",
+    "    strategy_repeat_count = np.array(strategy_repeat_count)\n",
+    "    n_strategies = len(strategy_set)\n",
+    "    old_number_of_samples = histogram.sum()\n",
+    "    new_number_of_samples = strategy_repeat_count.sum()\n",
+    "    sequences = sum([count*len(pack) for count, pack in\n",
+    "                     zip(strategy_repeat_count, strategy_set)])\n",
+    "    total_tokens = max_sequence_length * new_number_of_samples\n",
+    "    empty_tokens = sum([count*(max_sequence_length-sum(pack)) for count, pack\n",
+    "                        in zip(strategy_repeat_count, strategy_set)])\n",
+    "    efficiency = 100 - empty_tokens / total_tokens * 100\n",
+    "    speedup_upper_bound = 1.0 / (1 - (histogram*(1 - sequence_lengths / max_sequence_length)).sum() / old_number_of_samples)\n",
+    "    packing_factor = sequences/sum(strategy_repeat_count)\n",
+    "    \n",
+    "    print(f\"Packing efficiency (fraction of real tokens): {efficiency:3.4f}\\n\",\n",
+    "          f\"Speed-up theoretical limit: {speedup_upper_bound:3.4f}\\n\",\n",
+    "          f\"Achieved speed-up over un-packed dataset: {old_number_of_samples/new_number_of_samples:3.5f}\\n\",\n",
+    "          f\"Runtime: Packed {old_number_of_samples} sequences in {duration:3.3f} seconds\\n\",\n",
+    "          f\"Average packing factor: {packing_factor}\")\n",
+    "    \n",
+    "\n",
+    "    return strategy_set, np.array(strategy_repeat_count)\n",
+    "\n",
+    "if train:\n",
+    "    train_strategy_set, train_strategy_repeat_count = shortest_pack_first_histogram_packing(\n",
+    "        histogram=train_histogram,\n",
+    "        max_sequence_length=max_seq_length,\n",
+    "        max_sequences_per_pack=max_seq_per_pack,\n",
+    "    )\n",
+    "\n",
+    "    train_mean_pack_size = len(tokenized_training_dataset['input_ids'])/sum(train_strategy_repeat_count)\n",
+    "\n",
+    "    print(\"Training: mean sequences per pack\", train_mean_pack_size)\n",
+    "\n",
+    "if validate:\n",
+    "    validation_strategy_set, validation_strategy_repeat_count = shortest_pack_first_histogram_packing(\n",
+    "        histogram=validation_histogram,\n",
+    "        max_sequence_length=max_seq_length,\n",
+    "        max_sequences_per_pack=max_seq_per_pack,\n",
+    "    )\n",
+    "\n",
+    "    val_mean_pack_size = len(tokenized_validation_dataset['input_ids'])/sum(validation_strategy_repeat_count)\n",
+    "    print(\"Validation: mean sequences per pack\", val_mean_pack_size)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46319488",
+   "metadata": {},
+   "source": [
+    "The mean sequences per pack indicate the actual improvement achieved during training as opposed to the `max_sequences_per_pack * global_batch_size` theoretical limit. From the packing output, it can be seen that for this dataset, we achieve a speed-up of 2.22 times the the throughput of an unpacked dataset, which complies with the mean sequences per pack.\n",
+    "\n",
+    "Next, lets take a closer look at the outputs of the packing algorithm:\n",
+    "\n",
+    "`strategy_set` is an optimal list of lists of sequence lengths that can be packed together:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "6537116c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "First 5 strategies:  [[384], [191, 193], [190, 194], [189, 195], [188, 196]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"First 5 strategies: \", train_strategy_set[:5])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55d4aca8",
+   "metadata": {},
+   "source": [
+    "`strategy_repeat_count` is a list where each value corresponds to a strategy from the `strategy_set` denoting how many times we can repeat such a combination of sequence lengths:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "b5211076",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "First 5 repeat counts:  [915  53  99 150 283]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"First 5 repeat counts: \", train_strategy_repeat_count[:5])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05bfc845",
+   "metadata": {},
+   "source": [
+    "So for instance, sequences with lengths 191 and 193 can be combined into a pack 53 times."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6937fb11",
+   "metadata": {},
+   "source": [
+    "The lengths of sequences in the dataset have been distributed into packs according to the algorithm. The next step is to extract the actual features of the dataset and pack them together to create a new, \"packed\" dataset. \n",
+    "\n",
+    "Previously, during tokenisation, the dataset was left unpadded to more efficiently allow sequences to be packed together. In the dataset creation function, the packed sequences are padded up to the maximum sequence length to maintain a constant input size.\n",
+    "\n",
+    "For SQuAD, during training, answers are determined using a start position and end position within the sequence. During preprocessing, these were converted from character positions to token positions. Now, during packing, as tokenized sequences are effectively being concatenated along the same dimension, the positions of the answer will change for any sequence that is not starting at index 0 within a pack. For example, in a pack with 2 sequences:\n",
+    "\n",
+    "Before packing:\n",
+    "```\n",
+    "Length of sequence 1: 100 tokens (index 0 to 99)   , start position: 30, end position: 35\n",
+    "Length of sequence 2: 120 tokens (index 0 to 119)  , start position: 15, end position: 25\n",
+    "```\n",
+    "After packing:\n",
+    "```\n",
+    "Length of sequence 1 in pack 1: 100 tokens (index 0 to 99)   , start position: 30, end position: 35\n",
+    "Length of sequence 2 in pack 1: 120 tokens (index 100 to 219), start position: 115, end position: 125 \n",
+    "```\n",
+    "\n",
+    "The positions have been shifted by the total length of preceding sequences in the pack,  We call this the `positions_offset`.\n",
+    "\n",
+    "Also, the attention mask, which would for an unpacked dataset be a boolean array where indices which constitute the sequence are 1s and padding is 0s, is modified. For a packed dataset, we use an array of incrementing integers denoting which sequence in a pack is in which position. For example:\n",
+    "\n",
+    "Before packing:\n",
+    "```\n",
+    "Attention mask for sequence 1: [1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0]\n",
+    "Attention mask for sequence 2: [1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0]\n",
+    "```\n",
+    "After packing:\n",
+    "```\n",
+    "Attention mask for packed sequence (1 and 2): [1 1 1 1 1 1 1 1 2 2 2 2 2 0 0 0 0]\n",
+    "```\n",
+    "\n",
+    "This packed attention mask will then be used in the model to create an extended boolean 2D attention mask to denote each individual sequence in a pack, a feature supported by BERT. This method of dataset construction is implemented in the following `create_dataset_from_strategy` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "1ca0f17a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Time to pack training dataset:  35.62147355079651\n",
+      "Time to pack validation dataset:  11.937204122543335\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 5. Generate the packed dataset using the strategy and return a torch dataset\n",
+    "\n",
+    "import itertools\n",
+    "import copy\n",
+    "\n",
+    "def create_dataset_from_strategy(data, strategy_set, strategy_repeat_count, max_seq_len, max_seq_per_pack, train=True, squad_validation=False):\n",
+    "    total_num_packs:int = np.sum(strategy_repeat_count)\n",
+    "\n",
+    "    # First sort the features by length, storing the length and the corresponding index.\n",
+    "    dataset_seq_lens:list = np.array([len(seq) for seq in data['input_ids']])\n",
+    "    len_sorted_seq_idxs = np.argsort(dataset_seq_lens)\n",
+    "    len_sorted_seq_lens = dataset_seq_lens[len_sorted_seq_idxs]\n",
+    "    sorted_seqs = np.stack((len_sorted_seq_lens, len_sorted_seq_idxs))\n",
+    "\n",
+    "    # Get the data from the tokenised dataset\n",
+    "    input_ids       = data['input_ids']\n",
+    "    attention_mask  = data['attention_mask']\n",
+    "    token_type_ids  = data['token_type_ids']\n",
+    "    start_positions = data['start_positions'] if train else None\n",
+    "    end_positions   = data['end_positions'] if train else None\n",
+    "    example_ids     = data['example_id'] if squad_validation else None\n",
+    "    offset_mapping  = data['offset_mapping'] if squad_validation else None\n",
+    "\n",
+    "    # Prepare the manually padded constant sized data\n",
+    "    packed_input_ids        = np.zeros((total_num_packs, max_seq_len), dtype=int)\n",
+    "    packed_attention_mask   = np.zeros((total_num_packs, max_seq_len), dtype=int)\n",
+    "    packed_token_type_ids   = np.zeros((total_num_packs, max_seq_len), dtype=int)\n",
+    "    packed_position_ids     = np.zeros((total_num_packs, max_seq_len), dtype=int)\n",
+    "\n",
+    "    # Pad labels with -100 to ensure these indices are ignored by the loss function in PyTorch\n",
+    "    if train:\n",
+    "        packed_start_positions  = -100 * np.ones((total_num_packs, max_seq_per_pack), dtype=int)\n",
+    "        packed_end_positions    = -100 * np.ones((total_num_packs, max_seq_per_pack), dtype=int)\n",
+    "    else:\n",
+    "        packed_start_positions  = None\n",
+    "        packed_end_positions    = None\n",
+    "    \n",
+    "    if squad_validation:\n",
+    "        packed_example_ids      = np.zeros((total_num_packs, max_seq_per_pack), dtype='<U32')\n",
+    "        packed_offset_mapping   = -np.ones((total_num_packs, max_seq_len, 2), dtype=int)\n",
+    "    else:\n",
+    "        packed_example_ids      = None\n",
+    "\n",
+    "    # Pack the data using the developed strategies\n",
+    "    pack_index = 0\n",
+    "    for i in range(len(strategy_repeat_count)):\n",
+    "        # Retrieve current strategy\n",
+    "        strategy = strategy_set[i]\n",
+    "\n",
+    "        # Offset applied to positions according to where they land in the packed sequence\n",
+    "        positions_offset = [sum(strategy[:n]) for n in range(len(strategy))]\n",
+    "\n",
+    "        # Iterate through number of repeats for this strategy, filling in a pack\n",
+    "        for _ in range(strategy_repeat_count[i]):\n",
+    "\n",
+    "            # Obtain last available indices that correspond to the lengths of sequences in the strategy\n",
+    "            ref_inds = []\n",
+    "            for x in strategy:\n",
+    "                ref_ind = np.argwhere(sorted_seqs[0] == x)[-1]\n",
+    "                sorted_seqs[0, ref_ind] = -1\n",
+    "                ref_inds.append(ref_ind)\n",
+    "\n",
+    "            inds = sorted_seqs[1, ref_inds].flatten()\n",
+    "\n",
+    "            # Concatenate the data for each input in the strategy together to create the pack\n",
+    "            input_id_pack       = list(itertools.chain(*[input_ids[x] for x in inds]))\n",
+    "            attention_mask_pack = list(itertools.chain(*[itertools.repeat(n+1, len(attention_mask[v])) for n,v in enumerate(inds)]))\n",
+    "            token_type_ids_pack = list(itertools.chain(*[token_type_ids[x] for x in inds]))\n",
+    "            position_ids_pack   = list(itertools.chain(*[range(0, len(attention_mask[v])) for n,v in enumerate(inds)]))\n",
+    "\n",
+    "            # Create the equivalent tokenised packed input\n",
+    "            packed_input_ids[pack_index, :len(input_id_pack)]            = input_id_pack\n",
+    "            packed_attention_mask[pack_index, :len(attention_mask_pack)] = attention_mask_pack\n",
+    "            packed_token_type_ids[pack_index, :len(token_type_ids_pack)] = token_type_ids_pack\n",
+    "            packed_position_ids[pack_index, :len(position_ids_pack)]     = position_ids_pack\n",
+    "\n",
+    "            if train:\n",
+    "                start_positions_pack = [max(start_positions[v] + positions_offset[n], 0) for n,v in enumerate(inds)]\n",
+    "                end_positions_pack   = [max(end_positions[v] + positions_offset[n], 0) for n,v in enumerate(inds)]\n",
+    "\n",
+    "                packed_start_positions[pack_index, :len(start_positions_pack)] = start_positions_pack\n",
+    "                packed_end_positions[pack_index, :len(end_positions_pack)]     = end_positions_pack\n",
+    "\n",
+    "            if squad_validation:\n",
+    "                example_ids_pack     = [example_ids[x] for x in inds]\n",
+    "                offset_mapping_pack  = list(itertools.chain(*[offset_mapping[x] for x in inds]))\n",
+    "               \n",
+    "                packed_example_ids[pack_index, :len(example_ids_pack)]         = example_ids_pack \n",
+    "                packed_offset_mapping[pack_index, :len(offset_mapping_pack)]   = offset_mapping_pack\n",
+    "        \n",
+    "            \n",
+    "            #Increment the pack_index to then create the next packed row in the dataset\n",
+    "            pack_index += 1\n",
+    "\n",
+    "    # We need to recreate the dataset as the number of rows have changed, this is preferable to trying to reshape the existing Huggingface dataset\n",
+    "    # Create a dictionary representing the original shape of the dataset with the fields required for the model\n",
+    "    packed_dataset = {\n",
+    "        'input_ids':packed_input_ids,\n",
+    "        'attention_mask':packed_attention_mask,\n",
+    "        'token_type_ids':packed_token_type_ids,\n",
+    "        'position_ids':packed_position_ids\n",
+    "    }\n",
+    "\n",
+    "    if train:\n",
+    "        packed_dataset['start_positions'] = packed_start_positions\n",
+    "        packed_dataset['end_positions'] = packed_end_positions\n",
+    "    \n",
+    "    if squad_validation:\n",
+    "        packed_dataset['example_ids'] = packed_example_ids\n",
+    "        packed_dataset['offset_mapping'] = packed_offset_mapping\n",
+    "    \n",
+    "    # Use the Huggingface Dataset library to create a dataset object from the dictionary.\n",
+    "    packed_dataset = Dataset.from_dict(packed_dataset)\n",
+    "    \n",
+    "\n",
+    "    return packed_dataset\n",
+    "\n",
+    "if train:\n",
+    "    packing_start = time.time()\n",
+    "    \n",
+    "    packed_train_dataset = create_dataset_from_strategy(\n",
+    "        data=tokenized_training_dataset, \n",
+    "        strategy_set=train_strategy_set,\n",
+    "        strategy_repeat_count=train_strategy_repeat_count,\n",
+    "        max_seq_len=max_seq_length,\n",
+    "        max_seq_per_pack=max_seq_per_pack,\n",
+    "        train=True \n",
+    "    )\n",
+    "    \n",
+    "    print(\"Time to pack training dataset: \", time.time() - packing_start)\n",
+    "    \n",
+    "    # Define the training columns\n",
+    "    train_columns = ['input_ids','attention_mask','token_type_ids','position_ids','start_positions','end_positions']\n",
+    "    \n",
+    "    # Change the format of the dataset to a PyTorch dataset, converting all relevant columns to PyTorch tensors.\n",
+    "    packed_train_dataset.set_format(type='torch', columns=train_columns)\n",
+    "\n",
+    "if validate:\n",
+    "    packing_start = time.time()\n",
+    "    \n",
+    "    packed_validation_dataset = create_dataset_from_strategy(\n",
+    "        data=tokenized_validation_dataset, \n",
+    "        strategy_set=validation_strategy_set,\n",
+    "        strategy_repeat_count=validation_strategy_repeat_count,\n",
+    "        max_seq_len=max_seq_length,\n",
+    "        max_seq_per_pack=max_seq_per_pack,\n",
+    "        train=False,\n",
+    "        squad_validation=True\n",
+    "    )\n",
+    "    \n",
+    "    print(\"Time to pack validation dataset: \", time.time() - packing_start)\n",
+    "    \n",
+    "    # Create a copy of the dataset with the original columns before converting to torch, this is needed for postprocessing\n",
+    "    packed_validation_dataset_unformatted = copy.deepcopy(packed_validation_dataset)\n",
+    "    \n",
+    "    # Define the validation columns\n",
+    "    val_columns = ['input_ids','attention_mask','token_type_ids','position_ids']\n",
+    "    packed_validation_dataset.set_format(type='torch', columns=val_columns)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "faa55869",
+   "metadata": {},
+   "source": [
+    "Finally, we have the tokenized, packed and PyTorch-formatted training and validation datasets."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1d8ce9c",
+   "metadata": {},
+   "source": [
+    "### 4. Modify the model to work with the packed dataset. \n",
+    "\n",
+    "Some model modifications are required to make packing work with BERT. For SQuAD, we create a custom output class to separate the logits according to each of the sequences within the pack and calculate the loss. This custom class: `PackedBertOutputsForQA`, takes place after the forward-pass stage of `BertForQuestionAnswering`. \n",
+    "\n",
+    "**Within the model:**\n",
+    "\n",
+    "The output logits are calculated on a token by token basis by using a custom extended `attention_mask` which identifies which part of the input corresponds to which sequence, and `position_ids` which identifies the order of tokens within each of the sequences. Hence, the output logits can be separated according to the indices of each of the sequences in the pack, and evaluated for loss separately.\n",
+    "\n",
+    "For this, a boolean `unpacking_mask` is created, of shape `[max_sequences_per_pack, max_sequence_length]` for each input in a batch, where each row has `1` determining where the indices correspond to that particular sequence, and `0` where indices correspond to other sequences in the pack. Multiplying this by the logits results in \"unpacked\" logits, where indices in a row not corresponding to a single sequence are discarded. This does not change the position of the output logits for the sequence, but simply zeros any logits before or after it, allowing the offset-adjusted start and end positions to be used to calculate loss.\n",
+    "\n",
+    "The final step is to flatten the first two dimensions of the logits and positions, effectively emulating a larger batch size such that:\n",
+    "\n",
+    "```\n",
+    "output_shape = [batch_size, max_sequences_per_pack, max_sequence_length]\n",
+    "flattened_output_shape = [batch_size * max_sequences_per_pack, max_sequence_length]\n",
+    "```\n",
+    "\n",
+    "Providing the loss or accuracy function with the shape it expects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "3215e6de",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import poptorch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as F\n",
+    "\n",
+    "from optimum.graphcore.models.bert.modeling_bert import BertPipelineMixin\n",
+    "\n",
+    "from transformers import BertForQuestionAnswering\n",
+    "from transformers.modeling_outputs import QuestionAnsweringModelOutput\n",
+    "\n",
+    "import forge as f\n",
+    "from typing import Optional, Tuple, Union\n",
+    "\n",
+    "class PackedBertOutputsForQA(nn.Module):\n",
+    "    def __init__(self, config):\n",
+    "        super().__init__()\n",
+    "        \n",
+    "        # Use the default QA model output formatting class to return outputs in the same form as the base model.\n",
+    "        self.output = QuestionAnsweringModelOutput\n",
+    "        self.max_sequences_per_pack = config.max_sequences_per_pack\n",
+    "\n",
+    "    def forward(self, final_layer_output, attention_mask, start_positions=None, end_positions=None):\n",
+    "\n",
+    "        # Create unpacking mask to separate packed logits out into sequence-specific logits only\n",
+    "        unpacking_mask = attention_mask[:,None,:].repeat(1, self.max_sequences_per_pack, 1)\n",
+    "        pack_seq_ids = torch.arange(1, self.max_sequences_per_pack + 1).view(self.max_sequences_per_pack, 1)\n",
+    "\n",
+    "        unpacking_mask = (unpacking_mask == pack_seq_ids)\n",
+    "\n",
+    "        # Expand start logits using mask to isolate logits for each internal sequence in the pack\n",
+    "        unpacked_start_logits = final_layer_output.start_logits[:,None,:] * unpacking_mask\n",
+    "        unpacked_end_logits = final_layer_output.end_logits[:,None,:] * unpacking_mask\n",
+    "\n",
+    "        # Calculate loss on logits/labels with initial [bs, mspp, ...] dims collapsed into one [bs*mspp, ...]\n",
+    "        total_loss = None\n",
+    "        if start_positions is not None and end_positions is not None:\n",
+    "            start_positions = start_positions.view(-1)\n",
+    "            end_positions = end_positions.view(-1)\n",
+    "\n",
+    "            unpacked_start_logits=unpacked_start_logits.contiguous()\n",
+    "            unpacked_end_logits=unpacked_end_logits.contiguous()\n",
+    "\n",
+    "            unpacked_start_logits = unpacked_start_logits.view(-1, unpacked_start_logits.shape[-1])\n",
+    "            unpacked_end_logits = unpacked_end_logits.view(-1, unpacked_end_logits.shape[-1])\n",
+    "\n",
+    "            loss_fct = nn.CrossEntropyLoss()\n",
+    "            start_loss = loss_fct(unpacked_start_logits, start_positions)\n",
+    "            end_loss = loss_fct(unpacked_end_logits, end_positions)\n",
+    "\n",
+    "            total_loss = (start_loss + end_loss) / 2\n",
+    "\n",
+    "        return self.output(\n",
+    "            loss= total_loss,\n",
+    "            start_logits= unpacked_start_logits, \n",
+    "            end_logits=unpacked_end_logits, \n",
+    "            hidden_states=final_layer_output.hidden_states, \n",
+    "            attentions=final_layer_output.attentions\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b549258d",
+   "metadata": {},
+   "source": [
+    "Next, lets put this output class in context by creating the model class. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ce97921",
+   "metadata": {},
+   "source": [
+    "The attention mask should be used in a specific way for packed-BERT. We will create a 2D attention mask which allows the cross-attention to treat each sequence of the pack separately and ignore padding. We can visualise this in the following example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "fd9c0246",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tensor([[[1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
+      "         [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
+      "         [0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
+      "         [0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
+      "         [0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],\n",
+      "         [0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],\n",
+      "         [0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],\n",
+      "         [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0],\n",
+      "         [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0],\n",
+      "         [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0],\n",
+      "         [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0],\n",
+      "         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
+      "         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
+      "         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n",
+      "         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]])\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "\n",
+    "# 1 : Flat attention mask genreated by the dataset. Each sequence has a different index. 0 is padding.\n",
+    "attention_mask = torch.tensor([[1,1,2,2,3,3,3,4,4,4,4,0,0,0,0]])\n",
+    "\n",
+    "# 2: Generate the extended boolean 2D attention mask\n",
+    "attention_mask = attention_mask[:, None, :].repeat(1, attention_mask.shape[1], 1)\n",
+    "attention_mask = (attention_mask == attention_mask.transpose(1, 2)) * (attention_mask != 0)\n",
+    "# Notice that the mask is always False for the padding tokens.\n",
+    "\n",
+    "print(attention_mask.to(int))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33f43976",
+   "metadata": {},
+   "source": [
+    "The attention mask conversion is the first step in the forward pass. This modified attention mask, along with all of the other necessary inputs, is propagated through the model to generate the final layer output. At this stage, the custom model diverges from the base model, and we pass the final layer output to the custom output function to extract logits and perform the loss calculation, which returns outputs in the same form as the base `BertForQuestionAnswering` model. \n",
+    "\n",
+    "For the most part, the custom `PackedBertForQuestionAnswering` class uses the same process as the default `BertForQuestionAnswering` from the 🤗 Transformers library. This custom class inherits and extends this base class. Also by inheriting from `BertPipelineMixin`, the `parallelize()` method is already implemented for the BERT body. We overload it to also place the classifier on the last IPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "54ea388b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class PackedBertForQuestionAnswering(BertForQuestionAnswering, BertPipelineMixin):\n",
+    "    def __init__(self, config):\n",
+    "        super().__init__(config)\n",
+    "        self.config.max_sequences_per_pack = max_seq_per_pack\n",
+    "        self.packed_outputs = PackedBertOutputsForQA(config)\n",
+    "\n",
+    "    def parallelize(self):\n",
+    "        super().parallelize()\n",
+    "        last_ipu = self.ipu_config.ipus_per_replica -1\n",
+    "        self.qa_outputs = poptorch.BeginBlock(self.qa_outputs, \"QA Outputs\", ipu_id=last_ipu)\n",
+    "        return self\n",
+    "\n",
+    "    def forward(self,\n",
+    "                input_ids: Optional[torch.Tensor] = None,\n",
+    "                attention_mask: Optional[torch.Tensor] = None,\n",
+    "                token_type_ids: Optional[torch.Tensor] = None,\n",
+    "                position_ids: Optional[torch.Tensor] = None,\n",
+    "                head_mask: Optional[torch.Tensor] = None,\n",
+    "                inputs_embeds: Optional[torch.Tensor] = None,\n",
+    "                start_positions: Optional[torch.Tensor] = None,\n",
+    "                end_positions: Optional[torch.Tensor] = None,\n",
+    "                output_attentions: Optional[bool] = None,\n",
+    "                output_hidden_states: Optional[bool] = None,\n",
+    "                return_dict: Optional[bool] = None,\n",
+    "            ) -> Union[Tuple[torch.Tensor], QuestionAnsweringModelOutput]:\n",
+    "\n",
+    "        # Create 3D attention mask for sequence specific attention in pack\n",
+    "        seq_len = input_ids.shape[1]\n",
+    "        packed_attention_mask = attention_mask[:, None, :].repeat(1, seq_len, 1)\n",
+    "        packed_attention_mask = (packed_attention_mask == packed_attention_mask.transpose(1, 2)) * (packed_attention_mask != 0)\n",
+    "\n",
+    "        # Run forwards pass through model without labels\n",
+    "        final_layer_output = super().forward(\n",
+    "            input_ids,\n",
+    "            attention_mask=packed_attention_mask,\n",
+    "            token_type_ids=token_type_ids,\n",
+    "            position_ids=position_ids\n",
+    "        )\n",
+    "\n",
+    "        # Custom PackedBert for SQuAD output, redirect from before loss function in transformers model class.\n",
+    "        output = self.packed_outputs(\n",
+    "            final_layer_output, \n",
+    "            attention_mask=attention_mask, \n",
+    "            start_positions=start_positions, \n",
+    "            end_positions=end_positions\n",
+    "        )\n",
+    "\n",
+    "        if start_positions is not None and end_positions is not None:\n",
+    "            return poptorch.identity_loss(output.loss, reduction='mean'), output.start_logits, output.end_logits\n",
+    "        else:\n",
+    "            return output.start_logits, output.end_logits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dff1b7b5",
+   "metadata": {},
+   "source": [
+    "Next, lets instantiate the configuration for our model class by generating a pretrained configuration for the checkpoint we are finetuning on, in this case `bert-base-uncased` and define the `max_position_embeddings`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "0f7b38b5",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BertConfig {\n",
+      "  \"_name_or_path\": \"bert-base-uncased\",\n",
+      "  \"architectures\": [\n",
+      "    \"BertForMaskedLM\"\n",
+      "  ],\n",
+      "  \"attention_probs_dropout_prob\": 0.1,\n",
+      "  \"classifier_dropout\": null,\n",
+      "  \"gradient_checkpointing\": false,\n",
+      "  \"hidden_act\": \"gelu\",\n",
+      "  \"hidden_dropout_prob\": 0.1,\n",
+      "  \"hidden_size\": 768,\n",
+      "  \"initializer_range\": 0.02,\n",
+      "  \"intermediate_size\": 3072,\n",
+      "  \"layer_norm_eps\": 1e-12,\n",
+      "  \"max_position_embeddings\": 384,\n",
+      "  \"model_type\": \"bert\",\n",
+      "  \"num_attention_heads\": 12,\n",
+      "  \"num_hidden_layers\": 12,\n",
+      "  \"pad_token_id\": 0,\n",
+      "  \"position_embedding_type\": \"absolute\",\n",
+      "  \"transformers_version\": \"4.20.1\",\n",
+      "  \"type_vocab_size\": 2,\n",
+      "  \"use_cache\": true,\n",
+      "  \"vocab_size\": 30522\n",
+      "}\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from transformers import AutoConfig\n",
+    "\n",
+    "config = AutoConfig.from_pretrained(model_checkpoint)\n",
+    "config.max_position_embeddings = max_seq_length\n",
+    "\n",
+    "print(config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b7dae37",
+   "metadata": {},
+   "source": [
+    "Now we can instantiate the model class with the config, loading the weights from the model checkpoint. For SQuAD, we can determine the number of \"labels\" as the two output types that will determine whether answers are correct or not, i.e., the start and end position."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "3285aaa3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Some weights of the model checkpoint at bert-base-uncased were not used when initializing PackedBertForQuestionAnswering: ['cls.seq_relationship.weight', 'cls.predictions.transform.LayerNorm.bias', 'cls.predictions.transform.dense.weight', 'cls.predictions.bias', 'cls.predictions.decoder.weight', 'cls.predictions.transform.dense.bias', 'cls.seq_relationship.bias', 'cls.predictions.transform.LayerNorm.weight']\n",
+      "- This IS expected if you are initializing PackedBertForQuestionAnswering from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
+      "- This IS NOT expected if you are initializing PackedBertForQuestionAnswering from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n",
+      "Some weights of PackedBertForQuestionAnswering were not initialized from the model checkpoint at bert-base-uncased and are newly initialized: ['qa_outputs.weight', 'qa_outputs.bias']\n",
+      "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n"
+     ]
+    }
+   ],
+   "source": [
+    "num_positions = 2 # start position, end position (1)\n",
+    "\n",
+    "model = PackedBertForQuestionAnswering(config).from_pretrained(model_checkpoint, num_labels=num_positions).half()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a9ab06f",
+   "metadata": {},
+   "source": [
+    "### 5. Define validation metrics\n",
+    "\n",
+    "Before training and evaluating, a custom postprocessing function needs to be defined for SQuAD. This is because we need to map the predictions of the model back to parts of the context in terms of the character positions in the original untokenized samples. The model predicts logits for the start and end token position of the answer.\n",
+    "\n",
+    "The purpose of the function is to identify each of the tokenized features according to their `example_ids` and map the start and end token positions for the output, taking the top-*n* logit indices and discarding all invalid solutions. It then uses the `offset_mapping` to map the start and end token-level positions back to character-level positions within the context, and generates a text answer using the original context. This text prediction can then be used to calculate accuracy metrics and compared to the target answer present in the dataset.\n",
+    "\n",
+    "The `postprocess_qa_predictions()` function is adapted for packing, taken directly from the existing [tutorial for SQuAD finetuning for the IPU](https://github.com/huggingface/optimum-graphcore/blob/main/notebooks/question_answering.ipynb) for an unpacked dataset. The full description for the use of this function is described in that tutorial, and only the major changes for packing are described here. \n",
+    "\n",
+    "The main changes to the function include: instead of iterating through all the features in the tokenized dataset, and obtaining the `example_id` field created during tokenization of the validation dataset, this function iterates through each feature within each pack, obtaining the corresponding `example_id` for each feature within the pack. It saves the index of the pack in the dataset, as well as the index of the feature within the pack, to allow the function to easily and linearly obtain the features to perform validation on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "bbfe52f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import copy\n",
+    "import collections\n",
+    "def postprocess_qa_predictions(\n",
+    "    raw_val_dataset,\n",
+    "    tokenized_val_dataset,\n",
+    "    raw_predictions,\n",
+    "    n_best_size=20,\n",
+    "    max_answer_length=30,\n",
+    "    squad_v2=False,\n",
+    "):\n",
+    "    all_start_logits, all_end_logits = raw_predictions\n",
+    "\n",
+    "    # The dataloader drop_last affects the dataset size due to the global batch size, so the number of predictions may be slightly less than the total amount of validation samples available:\n",
+    "    dataloader_cap = all_start_logits.shape[0]\n",
+    "\n",
+    "    # Build a map example to its corresponding features.\n",
+    "    example_id_to_index = {k: i for i, k in enumerate(raw_val_dataset[\"id\"])}\n",
+    "\n",
+    "    features_per_example = collections.defaultdict(list)\n",
+    "\n",
+    "    for i, feature in enumerate(tokenized_val_dataset):\n",
+    "        for j, example_id in enumerate(feature[\"example_ids\"]):\n",
+    "            if example_id != '':\n",
+    "                features_per_example[example_id_to_index[example_id]].append([i,j])\n",
+    "\n",
+    "    # The dictionaries we have to fill.\n",
+    "    predictions = collections.OrderedDict()\n",
+    "\n",
+    "    # Logging.\n",
+    "    print(\n",
+    "        f\"Post-processing {len(raw_val_dataset)} example predictions split into {len(tokenized_val_dataset)} features.\"\n",
+    "    )\n",
+    "\n",
+    "    # Let's loop over all the examples!\n",
+    "    for example_index, example in enumerate(tqdm(raw_val_dataset)):\n",
+    "        # Those are the indices of the features associated to the current example.\n",
+    "        feature_indices = features_per_example[example_index]\n",
+    "        \n",
+    "        min_null_score = None  # Only used if squad_v2 is True.\n",
+    "        valid_answers = []\n",
+    "\n",
+    "        context = example[\"context\"]\n",
+    "        # Looping through all the features associated to the current example.\n",
+    "        for feature_index in feature_indices:\n",
+    "\n",
+    "            # Separate the feature index and the pack index (i.e. the index of the feature in the pack)\n",
+    "            pack_index, sequence_in_pack_index = feature_index\n",
+    "            \n",
+    "            # We want to ignore any indices of packs which were ignored by the validation loop due to the dataloader dropping uneven batches.\n",
+    "            if pack_index >= dataloader_cap: \n",
+    "                continue\n",
+    "\n",
+    "            # We grab the predictions of the model for this feature to map character-level spans from the offset.\n",
+    "            start_logits = all_start_logits[pack_index,sequence_in_pack_index]\n",
+    "            end_logits = all_end_logits[pack_index,sequence_in_pack_index]\n",
+    "\n",
+    "            # Update minimum null prediction.\n",
+    "            offset_mapping = tokenized_val_dataset[pack_index][\"offset_mapping\"]\n",
+    "\n",
+    "            # If squad_v2 dataset is used, we need to account for null predictions; we determine the minimum null score using input_ids to find the cls_index of the current sequence in the pack.\n",
+    "            if squad_v2:\n",
+    "                input_ids = tokenized_val_dataset[pack_index]['input_ids']\n",
+    "                \n",
+    "                cls_indices = [k for k,v in enumerate(input_ids) if v == int(tokenizer.cls_token_id)]\n",
+    "                cls_index = cls_indices[sequence_in_pack_index]\n",
+    "\n",
+    "                # Since we know the relevant CLS index for this sequence in the pack, the null score can be evaluated\n",
+    "                feature_null_score = start_logits[cls_index] + end_logits[cls_index]\n",
+    "\n",
+    "                if min_null_score is None or min_null_score < feature_null_score:\n",
+    "                    min_null_score = feature_null_score\n",
+    "\n",
+    "            # Go through all possibilities for the `n_best_size` greater start and end logits.\n",
+    "            start_indexes = np.argsort(start_logits)[-1 : -n_best_size - 1 : -1].tolist()\n",
+    "            end_indexes = np.argsort(end_logits)[-1 : -n_best_size - 1 : -1].tolist()\n",
+    "\n",
+    "            for start_index in start_indexes:\n",
+    "                for end_index in end_indexes:\n",
+    "                    # Don't consider out-of-scope answers, either because the indices are out of bounds or correspond to part of the input_ids that are not in the context.\n",
+    "                    if (\n",
+    "                        start_index >= len(offset_mapping)\n",
+    "                        or end_index >= len(offset_mapping)\n",
+    "                        or offset_mapping[start_index] is None\n",
+    "                        or offset_mapping[end_index] is None\n",
+    "                        or offset_mapping[start_index] == []\n",
+    "                        or offset_mapping[end_index] == []\n",
+    "                    ):\n",
+    "                        continue\n",
+    "                    # Don't consider answers with a length that is either < 0 or > max_answer_length.\n",
+    "                    if (\n",
+    "                        end_index < start_index\n",
+    "                        or end_index - start_index + 1 > max_answer_length\n",
+    "                    ):\n",
+    "                        continue\n",
+    "\n",
+    "                    start_char = offset_mapping[start_index][0]\n",
+    "                    end_char = offset_mapping[end_index][1]\n",
+    "                    valid_answers.append(\n",
+    "                        {\n",
+    "                            \"score\": start_logits[start_index] + end_logits[end_index],\n",
+    "                            \"text\": context[start_char:end_char],\n",
+    "                        }\n",
+    "                    )\n",
+    "\n",
+    "        if len(valid_answers) > 0:\n",
+    "            best_answer = sorted(valid_answers, key=lambda x: x[\"score\"], reverse=True)[\n",
+    "                0\n",
+    "            ]\n",
+    "        else:\n",
+    "            # In the very rare edge case we have not a single non-null prediction, we create a fake prediction to avoid\n",
+    "            # failure.\n",
+    "            best_answer = {\"text\": \"\", \"score\": 0.0}\n",
+    "\n",
+    "        # Let's pick our final answer: the best one or the null answer (only for squad_v2)\n",
+    "        if not squad_v2:\n",
+    "            predictions[example[\"id\"]] = best_answer[\"text\"]\n",
+    "        else:\n",
+    "            answer = (\n",
+    "                best_answer[\"text\"] if best_answer[\"score\"] > min_null_score else \"\"\n",
+    "            )\n",
+    "            predictions[example[\"id\"]] = answer\n",
+    "\n",
+    "    return predictions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38c76b0b",
+   "metadata": {},
+   "source": [
+    "Finally, a `compute_validation_metrics` function is created to take in the postprocessed predictions. This obtains the answers from the dataset, maps them according to the `example_id` to the corresponding prediction, and uses `metric` from the 🤗 Evaluate library to compute the relevant metrics for SQuAD, including an \"exact match\" accuracy, as well as F1 score, for each answer. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "5420ef6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compute_validation_metrics(predictions, raw_validation_dataset, packed_validation_dataset_unformatted, metric):\n",
+    "    \n",
+    "    target_answers = [\n",
+    "        {\"id\": ex[\"id\"], \"answers\": ex[\"answers\"]} for ex in raw_validation_dataset\n",
+    "    ]\n",
+    "    \n",
+    "    final_predictions = postprocess_qa_predictions(\n",
+    "        raw_validation_dataset, packed_validation_dataset_unformatted, predictions\n",
+    "    )\n",
+    "\n",
+    "    formatted_predictions = [\n",
+    "        {\"id\": k, \"prediction_text\": v} for k, v in final_predictions.items()\n",
+    "    ]\n",
+    "\n",
+    "    metrics = metric.compute(predictions=formatted_predictions, references=target_answers)\n",
+    "    \n",
+    "    return metrics\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acdde982",
+   "metadata": {},
+   "source": [
+    "### 6. Train and validate the model using the 🤗 Optimum Graphcore `Trainer`\n",
+    "\n",
+    "Now let's prepare the model for IPU, instantiate the IPU dataloader and machine configurations and create an IPU Trainer to efficiently and easily perform training on the IPU in just a few lines."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d680c50",
+   "metadata": {},
+   "source": [
+    "As we are using a pre-trained checkpoint, we can use the existing IPU configuration for `\"Graphcore/bert-base-uncased\"`for the custom model. This should require no changes as even though the model has been modified to be compatible with a packed dataset, the pipelining stages and IPU options will remain the same. \n",
+    "\n",
+    "Some of the options have been specified when defining the `ipu_config` to highlight the global batch size. This uses the configurations defined at the beginning of this script. Note that we can also define inference specific device iterations and replication factors for performing validation on the model, to modify the validation global batch size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "75cadf44",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/localdata/arsalanu/cloud-ISV/optimum-graphcore/optimum/graphcore/ipu_configuration.py:148: UserWarning: The \"enable_half_first_order_momentum\" parameter is deprecated\n",
+      "  warnings.warn('The \"enable_half_first_order_momentum\" parameter is deprecated')\n"
+     ]
+    }
+   ],
+   "source": [
+    "from optimum.graphcore import IPUConfig, IPUTrainer, IPUTrainingArguments\n",
+    "\n",
+    "ipu_config = IPUConfig.from_pretrained(\n",
+    "    ipu_config_name,\n",
+    "    executable_cache_dir = \"./cache-dir\",\n",
+    "    replication_factor=replication_factor,\n",
+    "    device_iterations=device_iterations,\n",
+    "    layers_per_ipu=[0,4,4,4],\n",
+    "    gradient_accumulation_steps=gradient_accumulation_steps,\n",
+    "    ipus_per_replica=4,\n",
+    "    embedding_serialization_factor=1,\n",
+    "    inference_device_iterations=device_iterations_val,\n",
+    "    inference_replication_factor=replication_factor_val,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a6b8635",
+   "metadata": {},
+   "source": [
+    "To instantiate an `IPUTrainer`, we will need to define `IPUTrainingArguments`, which is a class that contains all the attributes to customize the training. It requires one folder name, which will be used to save the checkpoints of the model, and all other arguments are optional:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "141a2e2d",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "training_args = IPUTrainingArguments(\n",
+    "    output_dir=\"checkpoints/bert-base-uncased_squadv1\",\n",
+    "    per_device_train_batch_size=1,#micro_batch_size_train,\n",
+    "    per_device_eval_batch_size=1,#micro_batch_size_eval,\n",
+    "    num_train_epochs=3,\n",
+    "    learning_rate=9e-05,\n",
+    "    weight_decay=0,\n",
+    "    loss_scaling=16.0,\n",
+    "    warmup_ratio=0.1,\n",
+    "    lr_scheduler_type='cosine',\n",
+    "    pod_type=pod_type,\n",
+    "    gradient_accumulation_steps=gradient_accumulation_steps,\n",
+    "    dataloader_drop_last=True,\n",
+    "    dataloader_num_workers=64,\n",
+    "    logging_steps=5\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5e150ed",
+   "metadata": {},
+   "source": [
+    "Note that we do not set evaluation to be performed during the training process. This is due to the custom postprocessing steps required to extract text-level answers for SQuAD, for which the logits cannot be easily modified without multiple function inputs, such as the tokenized and raw datasets, while the `preprocess_logits_for_metrics` argument provided in `IPUTrainingArguments` can only utilise logits alone. Therefore, validation is done after training."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eeb965d0",
+   "metadata": {},
+   "source": [
+    "We will need a data collator that will batch our processed examples together, here we will use the default data collator imported from the Transformers library. This is passed to the `IPUTrainer` class. \n",
+    "\n",
+    "Then we just need to pass all of this along with our datasets to the IPUTrainer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "561a41ca",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Setting replicated_tensor_sharding to False when replication_factor=1\n",
+      "/localdata/arsalanu/cloud-ISV/optimum-graphcore/optimum/graphcore/ipu_configuration.py:140: UserWarning: The \"sharded_execution_for_inference\" parameter is deprecated, sharded execution is always used during inference\n",
+      "  warnings.warn(\n",
+      "Overriding IPU config: gradient_accumulation_steps=32\n",
+      "-------------------- Device Allocation --------------------\n",
+      "Embedding --> IPU 0\n",
+      "Encoder 0  --> IPU 1\n",
+      "Encoder 1  --> IPU 1\n",
+      "Encoder 2  --> IPU 1\n",
+      "Encoder 3  --> IPU 1\n",
+      "Encoder 4  --> IPU 2\n",
+      "Encoder 5  --> IPU 2\n",
+      "Encoder 6  --> IPU 2\n",
+      "Encoder 7  --> IPU 2\n",
+      "Encoder 8  --> IPU 3\n",
+      "Encoder 9  --> IPU 3\n",
+      "Encoder 10 --> IPU 3\n",
+      "Encoder 11 --> IPU 3\n"
+     ]
+    }
+   ],
+   "source": [
+    "from transformers import default_data_collator\n",
+    "\n",
+    "trainer = IPUTrainer(\n",
+    "    model=model,\n",
+    "    ipu_config=ipu_config,\n",
+    "    args=training_args,\n",
+    "    train_dataset=packed_train_dataset,\n",
+    "    data_collator=default_data_collator\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07b0933f",
+   "metadata": {},
+   "source": [
+    "We can now finetune our model by just calling the train method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "c4cbe563",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Compiling Model...\n",
+      "[15:11:25.277] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 11 sizes=[1, 512], type=Int (type coerced from Long to Int)\n",
+      "[15:11:25.278] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 13 sizes=[1, 512], type=Int (type coerced from Long to Int)\n",
+      "[15:11:25.487] [poptorch:cpp] [warning] Parameter bert.embeddings.position_ids: impl_ 0xafde5a0 type xla ID 12 sizes [1, 512] dtype int was downgraded to constant because PopART doesn't support non floating point parameters\n",
+      "[15:11:25.487] [poptorch:cpp] [warning] Parameter bert.embeddings.token_type_ids: impl_ 0xaf525d0 type xla ID 14 sizes [1, 512] dtype int was downgraded to constant because PopART doesn't support non floating point parameters\n",
+      "[15:11:25.492] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 403 sizes=[1, 384], type=Int (type coerced from Long to Int)\n",
+      "[15:11:25.492] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 405 sizes=[1, 384], type=Int (type coerced from Long to Int)\n",
+      "[15:11:25.492] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 407 sizes=[1, 384], type=Int (type coerced from Long to Int)\n",
+      "[15:11:25.492] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 409 sizes=[1, 384], type=Int (type coerced from Long to Int)\n",
+      "[15:11:25.492] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 411 sizes=[1, 3], type=Int (type coerced from Long to Int)\n",
+      "[15:11:25.492] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 413 sizes=[1, 3], type=Int (type coerced from Long to Int)\n",
+      "[15:11:25.495] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x8a5af30) type coerced from Double to Float\n",
+      "[15:11:25.495] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x8a5af30) type coerced from Double to Float\n",
+      "[15:11:25.501] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0xd69b9a0) type coerced from Double to Float\n",
+      "[15:11:25.509] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0xf83f7c0) type coerced from Double to Float\n",
+      "[15:11:25.517] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x13b57410) type coerced from Double to Float\n",
+      "[15:11:25.524] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0xca1f620) type coerced from Double to Float\n",
+      "[15:11:25.532] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0xfb54a90) type coerced from Double to Float\n",
+      "[15:11:25.539] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x1d7950e0) type coerced from Double to Float\n",
+      "[15:11:25.547] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x17b44450) type coerced from Double to Float\n",
+      "[15:11:25.554] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0xf20f9a0) type coerced from Double to Float\n",
+      "[15:11:25.561] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0xf419490) type coerced from Double to Float\n",
+      "[15:11:25.568] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x89d1d10) type coerced from Double to Float\n",
+      "[15:11:25.576] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x2d4574f0) type coerced from Double to Float\n",
+      "[15:11:25.583] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0xe843390) type coerced from Double to Float\n",
+      "[15:11:25.600] [poptorch::python] [warning] No device set in torch.arange(): forcing to IPU\n",
+      "[15:11:25.601] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 1145 sizes=[0], type=Int (type coerced from Long to Int)\n",
+      "[15:11:25.603] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x8a3f180) type coerced from Long to Int\n",
+      "Graph compilation: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:10<00:00]\n",
+      "Compiled/Loaded model in 211.30561455339193 secs\n",
+      "***** Running training *****\n",
+      "  Num examples = 39826\n",
+      "  Num Epochs = 3\n",
+      "  Instantaneous batch size per device = 1\n",
+      "  Total train batch size (w. parallel, distributed & accumulation) = 512\n",
+      "  Gradient Accumulation steps = 32\n",
+      "  Total optimization steps = 231\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2a69f9dadca84c4aa8c9850229ed0d21",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/231 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'loss': 5.0664, 'learning_rate': 1.8750000000000002e-05, 'epoch': 0.06}\n",
+      "{'loss': 2.5197, 'learning_rate': 3.7500000000000003e-05, 'epoch': 0.13}\n",
+      "{'loss': 2.2133, 'learning_rate': 5.6250000000000005e-05, 'epoch': 0.19}\n",
+      "{'loss': 2.3999, 'learning_rate': 7.500000000000001e-05, 'epoch': 0.26}\n",
+      "{'loss': 1.8794, 'learning_rate': 8.999481757248478e-05, 'epoch': 0.32}\n",
+      "{'loss': 0.7152, 'learning_rate': 8.981355791391891e-05, 'epoch': 0.39}\n",
+      "{'loss': 0.584, 'learning_rate': 8.937436931344562e-05, 'epoch': 0.45}\n",
+      "{'loss': 0.9683, 'learning_rate': 8.867977956524798e-05, 'epoch': 0.52}\n",
+      "{'loss': 1.4863, 'learning_rate': 8.773378645051438e-05, 'epoch': 0.58}\n",
+      "{'loss': 1.12, 'learning_rate': 8.654183472780657e-05, 'epoch': 0.65}\n",
+      "{'loss': 1.0146, 'learning_rate': 8.511078479520392e-05, 'epoch': 0.71}\n",
+      "{'loss': 1.2082, 'learning_rate': 8.344887320459199e-05, 'epoch': 0.78}\n",
+      "{'loss': 0.6567, 'learning_rate': 8.156566525535925e-05, 'epoch': 0.84}\n",
+      "{'loss': 2.3417, 'learning_rate': 7.947199994035401e-05, 'epoch': 0.91}\n",
+      "{'loss': 0.6583, 'learning_rate': 7.717992756097047e-05, 'epoch': 0.97}\n",
+      "{'loss': 1.2918, 'learning_rate': 7.47026403704264e-05, 'epoch': 1.04}\n",
+      "{'loss': 0.4785, 'learning_rate': 7.205439664442229e-05, 'epoch': 1.1}\n",
+      "{'loss': 0.6745, 'learning_rate': 6.925043861620091e-05, 'epoch': 1.17}\n",
+      "{'loss': 0.7184, 'learning_rate': 6.630690474834003e-05, 'epoch': 1.23}\n",
+      "{'loss': 0.4155, 'learning_rate': 6.324073684620726e-05, 'epoch': 1.3}\n",
+      "{'loss': 0.7325, 'learning_rate': 6.006958254769438e-05, 'epoch': 1.36}\n",
+      "{'loss': 0.8073, 'learning_rate': 5.681169375046172e-05, 'epoch': 1.43}\n",
+      "{'loss': 0.5355, 'learning_rate': 5.348582156130461e-05, 'epoch': 1.49}\n",
+      "{'loss': 1.157, 'learning_rate': 5.011110837227137e-05, 'epoch': 1.56}\n",
+      "{'loss': 0.7229, 'learning_rate': 4.6706977684699715e-05, 'epoch': 1.62}\n",
+      "{'loss': 0.3342, 'learning_rate': 4.329302231530029e-05, 'epoch': 1.69}\n",
+      "{'loss': 1.5374, 'learning_rate': 3.988889162772863e-05, 'epoch': 1.75}\n",
+      "{'loss': 0.5284, 'learning_rate': 3.6514178438695395e-05, 'epoch': 1.82}\n",
+      "{'loss': 1.2006, 'learning_rate': 3.318830624953828e-05, 'epoch': 1.88}\n",
+      "{'loss': 0.2139, 'learning_rate': 2.9930417452305623e-05, 'epoch': 1.95}\n",
+      "{'loss': 0.4372, 'learning_rate': 2.6759263153792742e-05, 'epoch': 2.01}\n",
+      "{'loss': 0.4389, 'learning_rate': 2.369309525165997e-05, 'epoch': 2.08}\n",
+      "{'loss': 0.8794, 'learning_rate': 2.0749561383799104e-05, 'epoch': 2.14}\n",
+      "{'loss': 0.7324, 'learning_rate': 1.794560335557771e-05, 'epoch': 2.21}\n",
+      "{'loss': 0.5732, 'learning_rate': 1.5297359629573614e-05, 'epoch': 2.27}\n",
+      "{'loss': 0.2524, 'learning_rate': 1.2820072439029524e-05, 'epoch': 2.34}\n",
+      "{'loss': 0.6709, 'learning_rate': 1.0528000059645995e-05, 'epoch': 2.4}\n",
+      "{'loss': 0.7564, 'learning_rate': 8.434334744640763e-06, 'epoch': 2.47}\n",
+      "{'loss': 0.3101, 'learning_rate': 6.551126795408015e-06, 'epoch': 2.53}\n",
+      "{'loss': 0.7481, 'learning_rate': 4.889215204796078e-06, 'epoch': 2.6}\n",
+      "{'loss': 0.3916, 'learning_rate': 3.4581652721934433e-06, 'epoch': 2.66}\n",
+      "{'loss': 0.6192, 'learning_rate': 2.266213549485637e-06, 'epoch': 2.73}\n",
+      "{'loss': 0.6207, 'learning_rate': 1.3202204347520264e-06, 'epoch': 2.79}\n",
+      "{'loss': 0.6546, 'learning_rate': 6.256306865543893e-07, 'epoch': 2.86}\n",
+      "{'loss': 0.4784, 'learning_rate': 1.8644208608109225e-07, 'epoch': 2.92}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "Training completed. Do not forget to share your model on huggingface.co/models =)\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'loss': 0.4106, 'learning_rate': 5.1824275152217994e-09, 'epoch': 2.99}\n",
+      "{'train_runtime': 303.2537, 'train_samples_per_second': 390.01, 'train_steps_per_second': 0.762, 'train_loss': 0.9812492932076062, 'epoch': 3.0}\n"
+     ]
+    }
+   ],
+   "source": [
+    "train_run_metrics = trainer.train()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6d0fc29",
+   "metadata": {},
+   "source": [
+    "Then save the model with the model checkpoint name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "625847dc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Saving model checkpoint to checkpoints/bert-base-uncased_squad\n",
+      "-------------------- Device Allocation --------------------\n",
+      "Embedding --> IPU 0\n",
+      "Encoder 0  --> IPU 1\n",
+      "Encoder 1  --> IPU 1\n",
+      "Encoder 2  --> IPU 1\n",
+      "Encoder 3  --> IPU 1\n",
+      "Encoder 4  --> IPU 2\n",
+      "Encoder 5  --> IPU 2\n",
+      "Encoder 6  --> IPU 2\n",
+      "Encoder 7  --> IPU 2\n",
+      "Encoder 8  --> IPU 3\n",
+      "Encoder 9  --> IPU 3\n",
+      "Encoder 10 --> IPU 3\n",
+      "Encoder 11 --> IPU 3\n",
+      "Configuration saved in checkpoints/bert-base-uncased_squad/ipu_config.json\n"
+     ]
+    }
+   ],
+   "source": [
+    "model_checkpoint_name = model_checkpoint.split(\"/\")[-1]\n",
+    "trainer.save_model(f\"checkpoints/{model_checkpoint_name}_{model_task}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c93fb854",
+   "metadata": {},
+   "source": [
+    "We can then perform the evaluation by using the `IPUTrainer`'s `predict` functionality. This provides all of the raw predictions for the packed inputs for validation. This will, be default, use the global batch size defined specifically for inference in the `IPUTrainingArguments`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "c65f6830",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The following columns in the test set  don't have a corresponding argument in `PoptorchPackedBertForQuestionAnswering.forward` and have been ignored: offset_mapping, example_ids.\n",
+      "Compiling Model...\n",
+      "[15:20:03.702] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 11 sizes=[1, 512], type=Int (type coerced from Long to Int)\n",
+      "[15:20:03.703] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 13 sizes=[1, 512], type=Int (type coerced from Long to Int)\n",
+      "[15:20:03.790] [poptorch:cpp] [warning] Parameter bert.embeddings.position_ids: impl_ 0x8a24f50 type xla ID 12 sizes [1, 512] dtype int was downgraded to constant because PopART doesn't support non floating point parameters\n",
+      "[15:20:03.790] [poptorch:cpp] [warning] Parameter bert.embeddings.token_type_ids: impl_ 0x2d2e4410 type xla ID 14 sizes [1, 512] dtype int was downgraded to constant because PopART doesn't support non floating point parameters\n",
+      "[15:20:03.791] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 403 sizes=[1, 384], type=Int (type coerced from Long to Int)\n",
+      "[15:20:03.792] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 405 sizes=[1, 384], type=Int (type coerced from Long to Int)\n",
+      "[15:20:03.792] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 407 sizes=[1, 384], type=Int (type coerced from Long to Int)\n",
+      "[15:20:03.792] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 409 sizes=[1, 384], type=Int (type coerced from Long to Int)\n",
+      "[15:20:03.794] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x2d381360) type coerced from Double to Float\n",
+      "[15:20:03.794] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x2d381360) type coerced from Double to Float\n",
+      "[15:20:03.800] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x222fa5a0) type coerced from Double to Float\n",
+      "[15:20:03.808] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x1f509440) type coerced from Double to Float\n",
+      "[15:20:03.815] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x10bd2390) type coerced from Double to Float\n",
+      "[15:20:03.822] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x309c2b20) type coerced from Double to Float\n",
+      "[15:20:03.829] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x2f9f06a0) type coerced from Double to Float\n",
+      "[15:20:03.837] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x1b4efe70) type coerced from Double to Float\n",
+      "[15:20:03.844] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x27608e00) type coerced from Double to Float\n",
+      "[15:20:03.851] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x673e2590) type coerced from Double to Float\n",
+      "[15:20:03.859] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x924a150) type coerced from Double to Float\n",
+      "[15:20:03.866] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x6332a3c0) type coerced from Double to Float\n",
+      "[15:20:03.873] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x299b1260) type coerced from Double to Float\n",
+      "[15:20:03.880] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0xafcd900) type coerced from Double to Float\n",
+      "[15:20:03.887] [poptorch::python] [warning] No device set in torch.arange(): forcing to IPU\n",
+      "[15:20:03.888] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 1141 sizes=[0], type=Int (type coerced from Long to Int)\n",
+      "Graph compilation: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:03<00:00]\n",
+      "Compiled/Loaded model in 79.38754804059863 secs\n",
+      "***** Running Prediction *****\n",
+      "  Num examples = 4982\n",
+      "  Batch size = 64\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f848adabe8be41579e9cdedf5e58ad89",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/77 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "raw_predictions = trainer.predict(packed_validation_dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7553b34d",
+   "metadata": {},
+   "source": [
+    "Once the predictions have been obtained, the validation metrics can be computed by passing into the `compute_validation_metrics` function. This, as described previously, performs the necessary postprocessing on the logits and obtains text answers, then computes the accuracy metrics (exact match and F1 score) for SQuAD finetuning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "825dd9a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Post-processing 10570 example predictions split into 4982 features.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1620c89b6ae6419f884fa03367afd442",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/10570 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'exact_match': 79.89593188268685, 'f1': 87.41333808617574}\n"
+     ]
+    }
+   ],
+   "source": [
+    "val_metrics = compute_validation_metrics(\n",
+    "    raw_predictions.predictions, raw_validation_dataset, packed_validation_dataset_unformatted, metric)\n",
+    "\n",
+    "print(val_metrics)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f6aa1aa",
+   "metadata": {},
+   "source": [
+    "We can test that the model has been trained and works as expected with a regular input for inference by using the `pipeline` function from the Transformers library. This lets us create a simple classifier with the supported `question-answering` pipeline, the existing `ipu_config`, our saved fine-tuned model and the existing tokenizer. \n",
+    "\n",
+    "Then, the classifier takes the question and context as arguments, and outputs the model's answer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "32b9a3ac",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "loading configuration file ipu_config.json from cache at /home/arsalanu/.cache/huggingface/transformers/15f3c7af48b0245ae53f2934def72ba8f03b62fd4c7802f3286f528fd9470d2f.ebc8c7ebb26c45361fbc38159a1d99c470b5a1fe33dd1fc296926c17d3befc93\n",
+      "IPUConfig {\n",
+      "  \"auto_loss_scaling\": false,\n",
+      "  \"device_iterations\": 1,\n",
+      "  \"embedding_serialization_factor\": 2,\n",
+      "  \"enable_half_partials\": true,\n",
+      "  \"executable_cache_dir\": \"./exe_cache\",\n",
+      "  \"execute_encoder_on_cpu_for_generation\": false,\n",
+      "  \"gradient_accumulation_steps\": 512,\n",
+      "  \"inference_device_iterations\": 4,\n",
+      "  \"inference_replication_factor\": 4,\n",
+      "  \"ipus_per_replica\": 4,\n",
+      "  \"layers_per_ipu\": [\n",
+      "    0,\n",
+      "    4,\n",
+      "    4,\n",
+      "    4\n",
+      "  ],\n",
+      "  \"matmul_proportion\": 0.22,\n",
+      "  \"optimizer_state_offchip\": false,\n",
+      "  \"optimum_version\": \"1.5.2.dev0\",\n",
+      "  \"output_mode\": \"final\",\n",
+      "  \"recompute_checkpoint_every_layer\": true,\n",
+      "  \"replicated_tensor_sharding\": true,\n",
+      "  \"replication_factor\": 4,\n",
+      "  \"seed\": 42,\n",
+      "  \"sharded_execution_for_inference\": false,\n",
+      "  \"transformers_version\": \"4.20.1\"\n",
+      "}\n",
+      "\n",
+      "-------------------- Device Allocation --------------------\n",
+      "Embedding --> IPU 0\n",
+      "Encoder 0  --> IPU 1\n",
+      "Encoder 1  --> IPU 1\n",
+      "Encoder 2  --> IPU 1\n",
+      "Encoder 3  --> IPU 1\n",
+      "Encoder 4  --> IPU 2\n",
+      "Encoder 5  --> IPU 2\n",
+      "Encoder 6  --> IPU 2\n",
+      "Encoder 7  --> IPU 2\n",
+      "Encoder 8  --> IPU 3\n",
+      "Encoder 9  --> IPU 3\n",
+      "Encoder 10 --> IPU 3\n",
+      "Encoder 11 --> IPU 3\n",
+      "QA Outputs --> IPU 3\n",
+      "-----------------------------------------------------------\n",
+      "No padding arguments specified, so pad to 384 by default. Inputs longer than 384 will be truncated.\n",
+      "[15:26:37.353] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 13 sizes=[1, 512], type=Int (type coerced from Long to Int)\n",
+      "[15:26:37.353] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 15 sizes=[1, 512], type=Int (type coerced from Long to Int)\n",
+      "[15:26:37.473] [poptorch:cpp] [warning] Parameter bert.embeddings.position_ids: impl_ 0x2a823520 type xla ID 14 sizes [1, 512] dtype int was downgraded to constant because PopART doesn't support non floating point parameters\n",
+      "[15:26:37.473] [poptorch:cpp] [warning] Parameter bert.embeddings.token_type_ids: impl_ 0x673d9a40 type xla ID 16 sizes [1, 512] dtype int was downgraded to constant because PopART doesn't support non floating point parameters\n",
+      "[15:26:37.474] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 405 sizes=[1, 384], type=Int (type coerced from Long to Int)\n",
+      "[15:26:37.474] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 407 sizes=[1, 384], type=Int (type coerced from Long to Int)\n",
+      "[15:26:37.475] [poptorch:cpp] [warning] [TRACING-2] Allocated tensor: 409 sizes=[1, 384], type=Int (type coerced from Long to Int)\n",
+      "[15:26:37.476] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x16844600) type coerced from Double to Float\n",
+      "[15:26:37.476] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x16844600) type coerced from Double to Float\n",
+      "[15:26:37.477] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x16b1f7d0) type coerced from Long to Int\n",
+      "[15:26:37.478] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x6263e810) type coerced from Long to Int\n",
+      "[15:26:37.483] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x1cf4fba0) type coerced from Double to Float\n",
+      "[15:26:37.491] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x15b54eb0) type coerced from Double to Float\n",
+      "[15:26:37.499] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x1ec97340) type coerced from Double to Float\n",
+      "[15:26:37.507] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x115f4a30) type coerced from Double to Float\n",
+      "[15:26:37.514] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0xa230f30) type coerced from Double to Float\n",
+      "[15:26:37.522] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x16716d80) type coerced from Double to Float\n",
+      "[15:26:37.529] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x210461e0) type coerced from Double to Float\n",
+      "[15:26:37.536] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x18e5de40) type coerced from Double to Float\n",
+      "[15:26:37.544] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x21034010) type coerced from Double to Float\n",
+      "[15:26:37.551] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x2ab7fe60) type coerced from Double to Float\n",
+      "[15:26:37.559] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x20c5d3f0) type coerced from Double to Float\n",
+      "[15:26:37.566] [poptorch:cpp] [warning] [TRACING-2] Tensor (ptr 0x1939af80) type coerced from Double to Float\n",
+      "\n",
+      "Graph compilation:   0%|                                                                                                                   | 0/100 [00:00<?]\u001b[A\n",
+      "Graph compilation: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:03<00:00]\u001b[A\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2016\n"
+     ]
+    }
+   ],
+   "source": [
+    "from optimum.graphcore import pipeline\n",
+    "\n",
+    "classifier = pipeline(\n",
+    "    'question-answering', \n",
+    "    model=f\"checkpoints/{model_checkpoint_name}_{model_task}\", \n",
+    "    ipu_config=ipu_config_name,\n",
+    "    tokenizer=tokenizer\n",
+    "    )\n",
+    "\n",
+    "result = classifier(question=\"What year was Graphcore founded?\",\n",
+    "           context=\"Graphcore is a British semiconductor company that develops accelerators for AI and ML. Graphcore was founded in 2016.\")\n",
+    "\n",
+    "print(result['answer'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40590971",
+   "metadata": {},
+   "source": [
+    "The answer is correct! We have now successfully fine-tuned BERT for question answering using the SQuAD dataset using a packed dataset, which significantly improved the training throughput. "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### What does this PR do?

Adds a variant of the notebook question_answering with a step-by-step implementation of packed-BERT for fine-tuning. There are modifications to preprocessing, dataset creation, the model class and postprocessing in comparison to unpacked question-answering, all highlighted in this notebook. I've read through and its ready for review, there could be stuff to add or remove.

## Notes on the notebook
**Question:** We would ideally like to have interleaved training-validation loops, but SQuAD validation accuracy metrics require custom processing for logits with multiple arguments to the `postprocess_qa_predictions `function. IPUTrainingArguments lets you add a `preprocess_logits_for_metrics` function but this only takes `logits `as an argument, with no discernible way to add multiple arguments or even `kwargs` (let me know if this is possible). For this reason I've done the validation process separately (after training) using `.predict()`

I've also added an example showing inference using HF pipelines with a single text input, because of the preset task-specific pipelines I've used an unpacked input with the default 'question answering' pipeline to prove model functionality. We can't yet do packed inference without incorporating preprocessing into the inference pipeline. I will remove this if it's not needed.
