### PR TITLE
Fix training mode outputs for roberta and distilbert mlm models

### DIFF
--- a/optimum/graphcore/models/distilbert/modeling_distilbert.py
+++ b/optimum/graphcore/models/distilbert/modeling_distilbert.py
@@ -225,7 +225,7 @@ class PipelinedDistilBertForMaskedLM(DistilBertForMaskedLM, DistilBertPipelineMi
         """
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        if labels is not None:
+        if self.training:
             dlbrt_output = self.distilbert(
                 input_ids=input_ids,
                 attention_mask=attention_mask,

--- a/optimum/graphcore/models/roberta/modeling_roberta.py
+++ b/optimum/graphcore/models/roberta/modeling_roberta.py
@@ -187,7 +187,7 @@ class PipelinedRobertaForMaskedLM(RobertaForMaskedLM, PipelineMixin):
         """
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        if labels is not None:
+        if self.training:
             outputs = self.roberta(
                 input_ids,
                 attention_mask=attention_mask,


### PR DESCRIPTION
# What does this PR do?

* In training mode for MLM models we don't want to return the logits for performance. 
* Distilbert and Roberta were only checking for `if labels is None`, but this meant that in evaluation the training path was being taken. Fix this by checking instead for `if self.training`. 

