### PR TITLE
Remove the custom layernorm for convnext

### DIFF
--- a/optimum/graphcore/models/convnext/modeling_convnext.py
+++ b/optimum/graphcore/models/convnext/modeling_convnext.py
@@ -12,15 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import torch
-import torch.nn as nn
-
 import poptorch
 from optimum.utils import logging
 from transformers.models.convnext.modeling_convnext import (
     ConvNextForImageClassification,
     ConvNextLayer,
-    ConvNextLayerNorm,
 )
 
 from ...modeling_utils import PipelineMixin, get_layer_ipu, register
@@ -28,36 +24,6 @@ from .optimized_convnextlayer import OptimizedConvNextLayer
 
 
 logger = logging.get_logger(__name__)
-
-
-class IPUConvNextLayerNorm(nn.Module):
-    r"""LayerNorm that supports two data formats: channels_last (default) or channels_first.
-    The ordering of the dimensions in the inputs. channels_last corresponds to inputs with shape (batch_size, height,
-    width, channels) while channels_first corresponds to inputs with shape (batch_size, channels, height, width).
-    """
-
-    def __init__(self, normalized_shape, eps=1e-4, data_format="channels_last"):
-        super().__init__()
-        self.weight = nn.Parameter(torch.ones(normalized_shape))
-        self.bias = nn.Parameter(torch.zeros(normalized_shape))
-        self.eps = eps
-        self.data_format = data_format
-        if self.data_format not in ["channels_last", "channels_first"]:
-            raise NotImplementedError(f"Unsupported data format: {self.data_format}")
-        self.normalized_shape = (normalized_shape,)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if self.data_format == "channels_last":
-            x = torch.nn.functional.layer_norm(x, self.normalized_shape, self.weight, self.bias, self.eps)
-        elif self.data_format == "channels_first":
-            input_dtype = x.dtype
-            x = x.float()
-            u = x.mean(1, keepdim=True)
-            s = (x - u).pow(2).mean(1, keepdim=True)
-            x = (x - u) / torch.sqrt(s + self.eps)
-            x = x.to(dtype=input_dtype)
-            x = self.weight[:, None, None] * x + self.bias[:, None, None]
-        return x
 
 
 @register(ConvNextForImageClassification)
@@ -69,12 +35,6 @@ class PipelinedConvNextForImageClassification(ConvNextForImageClassification, Pi
         for stage in self.convnext.encoder.stages:
             for layer in stage.layers:
                 layer.__class__ = OptimizedConvNextLayer
-
-        # ConvNextLayerNorm does not correctly handle fp16.
-        # TODO remove this in newer version of transformers that has https://github.com/huggingface/transformers/pull/18746
-        for mod in self.modules():
-            if isinstance(mod, ConvNextLayerNorm):
-                mod.__class__ = IPUConvNextLayerNorm
 
         logger.info("---------- Device Allocation -----------")
         logger.info(f"Embedding  --> IPU 0")
@@ -99,11 +59,6 @@ class PipelinedConvNextForImageClassification(ConvNextForImageClassification, Pi
 
     def deparallelize(self):
         super().deparallelize()
-
-        for mod in self.modules():
-            if isinstance(mod, IPUConvNextLayerNorm):
-                mod.__class__ = ConvNextLayerNorm
-
         # Switch back to non-optimized ConvNextLayer
         for stage in self.convnext.encoder.stages:
             for layer in stage.layers:

--- a/optimum/graphcore/models/convnext/modeling_convnext.py
+++ b/optimum/graphcore/models/convnext/modeling_convnext.py
@@ -14,10 +14,7 @@
 
 import poptorch
 from optimum.utils import logging
-from transformers.models.convnext.modeling_convnext import (
-    ConvNextForImageClassification,
-    ConvNextLayer,
-)
+from transformers.models.convnext.modeling_convnext import ConvNextForImageClassification, ConvNextLayer
 
 from ...modeling_utils import PipelineMixin, get_layer_ipu, register
 from .optimized_convnextlayer import OptimizedConvNextLayer


### PR DESCRIPTION
# What does this PR do?

* Removes the custom layernorm used in convnext that correctly handled mixed precision. This fix is now in upstream transformers since 4.23 so we remove it from here. 
