### PR TITLE
remove predict_with_generate flag from example command in README as i…

### DIFF
--- a/examples/summarization/README.md
+++ b/examples/summarization/README.md
@@ -50,7 +50,6 @@ python examples/summarization/run_summarization.py \
     --max_grad_norm 0.5 \
     --pad_to_max_length \
     --dataloader_drop_last \
-    --predict_with_generate \
     --generation_num_beams 2 \
     --output_dir /tmp/t5-summarization \
     --overwrite_output_dir
@@ -85,7 +84,6 @@ python examples/summarization/run_summarization.py \
     --max_grad_norm 0.5 \
     --pad_to_max_length \
     --dataloader_drop_last \
-    --predict_with_generate \
     --generation_num_beams 2 \
     --output_dir /tmp/t5-summarization \
 ```
@@ -113,7 +111,6 @@ python examples/summarization/run_summarization.py \
     --max_grad_norm 0.5 \
     --pad_to_max_length \
     --dataloader_drop_last \
-    --predict_with_generate \
     --generation_num_beams 2 \
     --output_dir /tmp/bart-summarization \
     --overwrite_output_dir

--- a/examples/summarization/README.md
+++ b/examples/summarization/README.md
@@ -50,7 +50,6 @@ python examples/summarization/run_summarization.py \
     --max_grad_norm 0.5 \
     --pad_to_max_length \
     --dataloader_drop_last \
-    --generation_num_beams 2 \
     --output_dir /tmp/t5-summarization \
     --overwrite_output_dir
 ```
@@ -84,7 +83,6 @@ python examples/summarization/run_summarization.py \
     --max_grad_norm 0.5 \
     --pad_to_max_length \
     --dataloader_drop_last \
-    --generation_num_beams 2 \
     --output_dir /tmp/t5-summarization \
 ```
 
@@ -111,7 +109,6 @@ python examples/summarization/run_summarization.py \
     --max_grad_norm 0.5 \
     --pad_to_max_length \
     --dataloader_drop_last \
-    --generation_num_beams 2 \
     --output_dir /tmp/bart-summarization \
     --overwrite_output_dir
 ```


### PR DESCRIPTION
Running the default command in `examples/summarization` leads to an error as the `predict_with_generate` flag is enabled by default. This PR removes it as it's not yet supported. 