### PR TITLE
Tokenclassification testfixes

### DIFF
--- a/optimum/graphcore/trainer.py
+++ b/optimum/graphcore/trainer.py
@@ -1081,7 +1081,7 @@ class IPUTrainer:
         logger.info(f"  Num Epochs = {num_train_epochs}")
         logger.info(f"  Instantaneous batch size per device = {batch_size}")
         logger.info(f"  Total train batch size (w. parallel, distributed & accumulation) = {total_train_batch_size}")
-        logger.info(f"  Gradient Accumulation steps = {args.gradient_accumulation_steps}")
+        logger.info(f"  Gradient Accumulation steps = {self.ipu_config.gradient_accumulation_steps}")
         logger.info(f"  Total optimization steps = {max_steps}")
 
         self.state.epoch = 0
@@ -1102,7 +1102,7 @@ class IPUTrainer:
             if not args.ignore_data_skip:
                 steps_trained_in_current_epoch = self.state.global_step % (num_update_steps_per_epoch)
                 # No need to multiply by the number of gradient accumulation steps as poptorch already accounts for that.
-                # steps_trained_in_current_epoch *= args.gradient_accumulation_steps
+                # steps_trained_in_current_epoch *= self.ipu_config.gradient_accumulation_steps
             else:
                 steps_trained_in_current_epoch = 0
 
@@ -1173,7 +1173,7 @@ class IPUTrainer:
             steps_in_epoch = (
                 len(epoch_iterator)
                 if has_length(train_dataloader)
-                else args.max_steps * args.gradient_accumulation_steps
+                else args.max_steps * self.ipu_config.gradient_accumulation_steps
             )
 
             self.control = self.callback_handler.on_epoch_begin(args, self.state, self.control)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -403,6 +403,41 @@ class TokenClassificationExampleTester(ExampleTesterBase, metaclass=ExampleTestM
     TRAIN_BATCH_SIZE = 1
     EVAL_BATCH_SIZE = 1
 
+    # override to use a higher learning rate of 1e-4
+    def _create_command_line(
+        self,
+        script: str,
+        model_name: str,
+        ipu_config_name: str,
+        output_dir: str,
+        task: Optional[str] = None,
+        dataset_config_name: Optional[str] = None,
+        do_eval: bool = True,
+        lr: float = 1e-4,
+        train_batch_size: int = 1,
+        eval_batch_size: int = 1,
+        num_epochs: int = 2,
+        inference_device_iterations: int = 6,
+        gradient_accumulation_steps: int = 64,
+        extra_command_line_arguments: Optional[List[str]] = None,
+    ) -> List[str]:
+        return super()._create_command_line(
+            script,
+            model_name,
+            ipu_config_name,
+            output_dir,
+            task=task,
+            dataset_config_name=dataset_config_name,
+            do_eval=do_eval,
+            lr=lr,
+            train_batch_size=train_batch_size,
+            eval_batch_size=eval_batch_size,
+            num_epochs=num_epochs,
+            inference_device_iterations=inference_device_iterations,
+            gradient_accumulation_steps=gradient_accumulation_steps,
+            extra_command_line_arguments=extra_command_line_arguments,
+        )
+
 
 class MultipleChoiceExampleTester(ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_swag"):
     # Using a small gradient accumulation steps value because input data is repated for the multiple choice task.

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -158,6 +158,7 @@ class ExampleTestMeta(type):
                     task=self.TASK_NAME,
                     dataset_config_name=self.DATASET_CONFIG_NAME,
                     do_eval=self.EVAL_IS_SUPPORTED,
+                    lr=self.LEARNING_RATE,
                     train_batch_size=self.TRAIN_BATCH_SIZE,
                     eval_batch_size=self.EVAL_BATCH_SIZE,
                     num_epochs=self.NUM_EPOCHS,
@@ -222,6 +223,7 @@ class ExampleTesterBase(TestCase):
     SCORE_NAME = "eval_accuracy"
     DATASET_PARAMETER_NAME = "dataset_name"
     NUM_EPOCHS = 1
+    LEARNING_RATE = 1e-5
     TRAIN_BATCH_SIZE = 2
     EVAL_BATCH_SIZE = 2
     INFERENCE_DEVICE_ITERATIONS = 4
@@ -402,41 +404,7 @@ class TokenClassificationExampleTester(ExampleTesterBase, metaclass=ExampleTestM
     TASK_NAME = "conll2003"
     TRAIN_BATCH_SIZE = 1
     EVAL_BATCH_SIZE = 1
-
-    # override to use a higher learning rate of 1e-4
-    def _create_command_line(
-        self,
-        script: str,
-        model_name: str,
-        ipu_config_name: str,
-        output_dir: str,
-        task: Optional[str] = None,
-        dataset_config_name: Optional[str] = None,
-        do_eval: bool = True,
-        lr: float = 1e-4,
-        train_batch_size: int = 1,
-        eval_batch_size: int = 1,
-        num_epochs: int = 2,
-        inference_device_iterations: int = 6,
-        gradient_accumulation_steps: int = 64,
-        extra_command_line_arguments: Optional[List[str]] = None,
-    ) -> List[str]:
-        return super()._create_command_line(
-            script,
-            model_name,
-            ipu_config_name,
-            output_dir,
-            task=task,
-            dataset_config_name=dataset_config_name,
-            do_eval=do_eval,
-            lr=lr,
-            train_batch_size=train_batch_size,
-            eval_batch_size=eval_batch_size,
-            num_epochs=num_epochs,
-            inference_device_iterations=inference_device_iterations,
-            gradient_accumulation_steps=gradient_accumulation_steps,
-            extra_command_line_arguments=extra_command_line_arguments,
-        )
+    LEARNING_RATE = 1e-4
 
 
 class MultipleChoiceExampleTester(ExampleTesterBase, metaclass=ExampleTestMeta, example_name="run_swag"):


### PR DESCRIPTION
Changes:
1. Increase learning rate for token classification tests from 1e-5 to 1e-4 to get a previously failing test to pass. 
2. Replaces incorrect usage of `training_args.gradient_accumulation_steps` with `ipu_config.gradient_accumulation_steps`, for example when logging training information. 

Tests:
Ran the token classification tests, all 6 tests passed. 