### PR TITLE
Layers per ipu improvements

### DIFF
--- a/notebooks/external_model.ipynb
+++ b/notebooks/external_model.ipynb
@@ -372,7 +372,7 @@
     "        self.word_embeddings = poptorch.BeginBlock(self.word_embeddings, \"word_embeddings\", ipu_id=0)\n",
     "        self.position_embeddings = poptorch.BeginBlock(self.position_embeddings, \"position_embeddings\", ipu_id=0)\n",
     "\n",
-    "        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu)\n",
+    "        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu, self.transformer_encoder.layers)\n",
     "        for index, layer in enumerate(self.transformer_encoder.layers):\n",
     "            if self.ipu_config.recompute_checkpoint_every_layer:\n",
     "                # Put checkpoints on every encoder layer\n",

--- a/optimum/graphcore/ipu_configuration.py
+++ b/optimum/graphcore/ipu_configuration.py
@@ -67,11 +67,11 @@ class IPUConfig(BaseConfig):
         layers_per_ipu (`List[int]`):
             Specifies the number of layers that will be put on each IPU for pipelined execution.
             For instance: `[2, 3, 4, 2]` specifies a 4-IPU pipeline, where the first two layers will be put on IPU0,
-            the following three on IPU1, the next four on IPU2 and the last two on IPU3. 
+            the following three on IPU1, the next four on IPU2 and the last two on IPU3.
             If the default of [-1] is used, the layers will be split evenly over `ipus_per_replica` IPUs.
-            The wildcard value '-1' can also be used in combination with integers. 
-            For instance: `[1, 2, -1, -1]` specifies a 4-IPU pipeline, where the first layer is put on IPU0, 
-            the next two layers on IPU1, and the remaining layers split evenly between IPU2 and IPU3. 
+            The wildcard value '-1' can also be used in combination with integers.
+            For instance: `[1, 2, -1, -1]` specifies a 4-IPU pipeline, where the first layer is put on IPU0,
+            the next two layers on IPU1, and the remaining layers split evenly between IPU2 and IPU3.
 
         > Parameters for memory management
 

--- a/optimum/graphcore/ipu_configuration.py
+++ b/optimum/graphcore/ipu_configuration.py
@@ -67,7 +67,11 @@ class IPUConfig(BaseConfig):
         layers_per_ipu (`List[int]`):
             Specifies the number of layers that will be put on each IPU for pipelined execution.
             For instance: `[2, 3, 4, 2]` specifies a 4-IPU pipeline, where the first two layers will be put on IPU0,
-            the following three on IPU1, the next four on IPU2 and the last two on IPU3.
+            the following three on IPU1, the next four on IPU2 and the last two on IPU3. 
+            If the default of [-1] is used, the layers will be split evenly over `ipus_per_replica` IPUs.
+            The wildcard value '-1' can also be used in combination with integers. 
+            For instance: `[1, 2, -1, -1]` specifies a 4-IPU pipeline, where the first layer is put on IPU0, 
+            the next two layers on IPU1, and the remaining layers split evenly between IPU2 and IPU3. 
 
         > Parameters for memory management
 
@@ -117,7 +121,7 @@ class IPUConfig(BaseConfig):
     def __init__(self, **kwargs):
         self.seed = kwargs.pop("seed", None)
 
-        self.layers_per_ipu = kwargs.pop("layers_per_ipu", [1])
+        self.layers_per_ipu = kwargs.pop("layers_per_ipu", [-1])
         self.ipus_per_replica = kwargs.pop("ipus_per_replica", len(self.layers_per_ipu))
 
         self.replication_factor = kwargs.pop("replication_factor", 1)

--- a/optimum/graphcore/modeling_utils.py
+++ b/optimum/graphcore/modeling_utils.py
@@ -227,27 +227,59 @@ class PipelineMixin:
 
 def get_layer_ipu(ipu_config: IPUConfig, target_number_of_layers: Optional[Union[int, List]] = None):
     layers_per_ipu = ipu_config.layers_per_ipu
+    ipus_per_replica = ipu_config.ipus_per_replica
     
     if target_number_of_layers is not None:
         if not isinstance(target_number_of_layers, (int, float)):
             target_number_of_layers = len(target_number_of_layers)
         
-        # if ipus_per_replica is 1, then put everything on IPU0, 
-        # ignoring layers_per_ipu 
-        if ipu_config.ipus_per_replica == 1:
+        # if ipus_per_replica is 1, then put everything on IPU0, ignoring layers_per_ipu 
+        if ipus_per_replica == 1:
             return [0] * target_number_of_layers
+        
+        elif ipus_per_replica > 1:
+            # default/wildcards - split layers evenly over all ipus
+            if layers_per_ipu in ([-1], [-1] * ipus_per_replica):
+                quotient, remainder = divmod(target_number_of_layers, ipus_per_replica)
+                layers_per_ipu = [quotient] * ipus_per_replica
+                if remainder > 0:
+                    # add any remainder layers to last wildcard IPU
+                    layers_per_ipu[-1] += remainder
+
+            # combination of wildcards and integers 
+            elif -1 in layers_per_ipu and len(layers_per_ipu) == ipus_per_replica:
+                wildcard_idxs = [idx for idx, v in enumerate(layers_per_ipu) if v == -1]
+                num_wildcard_ipus = len(wildcard_idxs)
+                # wildcard_layers = target_num_layers - num_non_wildcard_layers
+                num_wildcard_layers = target_number_of_layers - sum([l for l in layers_per_ipu if l != -1])
+                quotient, remainder = divmod(num_wildcard_layers, num_wildcard_ipus)
+                for idx in wildcard_idxs:
+                    layers_per_ipu[idx] = quotient
+                if remainder > 0:
+                    # add any remainder layers to last wildcard IPU
+                    layers_per_ipu[wildcard_idxs[-1]] += remainder
+
+            # wildcard used, but len(layers_per_ipu) !=  ipus_per_replica
+            elif -1 in layers_per_ipu:
+                raise ValueError(
+                    "layers_per_ipu has non-default value set, but its length does not match ipus_per_replica. "
+                    f"layers_per_ipu={layers_per_ipu}, ipus_per_replica={ipus_per_replica}. "
+                )
+            # no wildcards used
+            elif sum(layers_per_ipu) < target_number_of_layers:
+                raise ValueError(
+                    "layers_per_ipu does not define enough layers for the current model."
+                    " The current IPU Config specifies IPU assignments for "
+                    f"{sum(layers_per_ipu)} layers but there are {target_number_of_layers} layers "
+                    f"in the model. layers_per_ipu={layers_per_ipu}"
+                )
+
 
     # List of the IPU Id for each encoder layer
     layer_ipu: List[int] = []
     for ipu, n_layers in enumerate(layers_per_ipu):
         layer_ipu += [ipu] * n_layers
-    if target_number_of_layers is not None and len(layer_ipu) < target_number_of_layers:
-        raise ValueError(
-            "layers_per_ipu does not define enough layers for the current model."
-            " The current IPU Config specifies IPU assignments for "
-            f"{len(layer_ipu)} layers but there are {target_number_of_layers} layers "
-            f"in the model. layers_per_ipu={layers_per_ipu}"
-        )
+
     return layer_ipu
 
 

--- a/optimum/graphcore/modeling_utils.py
+++ b/optimum/graphcore/modeling_utils.py
@@ -228,15 +228,15 @@ class PipelineMixin:
 def get_layer_ipu(ipu_config: IPUConfig, target_number_of_layers: Optional[Union[int, List]] = None):
     layers_per_ipu = ipu_config.layers_per_ipu
     ipus_per_replica = ipu_config.ipus_per_replica
-    
+
     if target_number_of_layers is not None:
         if not isinstance(target_number_of_layers, (int, float)):
             target_number_of_layers = len(target_number_of_layers)
-        
-        # if ipus_per_replica is 1, then put everything on IPU0, ignoring layers_per_ipu 
+
+        # if ipus_per_replica is 1, then put everything on IPU0, ignoring layers_per_ipu
         if ipus_per_replica == 1:
             return [0] * target_number_of_layers
-        
+
         elif ipus_per_replica > 1:
             # default/wildcards - split layers evenly over all ipus
             if layers_per_ipu in ([-1], [-1] * ipus_per_replica):
@@ -246,7 +246,7 @@ def get_layer_ipu(ipu_config: IPUConfig, target_number_of_layers: Optional[Union
                     # add any remainder layers to last wildcard IPU
                     layers_per_ipu[-1] += remainder
 
-            # combination of wildcards and integers 
+            # combination of wildcards and integers
             elif -1 in layers_per_ipu and len(layers_per_ipu) == ipus_per_replica:
                 wildcard_idxs = [idx for idx, v in enumerate(layers_per_ipu) if v == -1]
                 num_wildcard_ipus = len(wildcard_idxs)
@@ -273,7 +273,6 @@ def get_layer_ipu(ipu_config: IPUConfig, target_number_of_layers: Optional[Union
                     f"{sum(layers_per_ipu)} layers but there are {target_number_of_layers} layers "
                     f"in the model. layers_per_ipu={layers_per_ipu}"
                 )
-
 
     # List of the IPU Id for each encoder layer
     layer_ipu: List[int] = []

--- a/optimum/graphcore/models/bart/modeling_bart.py
+++ b/optimum/graphcore/models/bart/modeling_bart.py
@@ -733,7 +733,7 @@ class PipelinedBartForConditionalGeneration(BartForConditionalGeneration, Pipeli
         )
 
         number_of_layers = len(self.model.encoder.layers) + len(self.model.decoder.layers)
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu, number_of_layers)
+        layer_ipu = get_layer_ipu(self.ipu_config, number_of_layers)
         for index, layer in enumerate(self.model.encoder.layers):
             ipu = layer_ipu[index]
             if self.ipu_config.recompute_checkpoint_every_layer and index != self.config.num_hidden_layers - 1:
@@ -870,7 +870,7 @@ class PipelinedBartForSequenceClassification(BartForSequenceClassification, Pipe
             self.model.encoder.layernorm_embedding, "Embedding", ipu_id=0
         )
         number_of_layers = len(self.model.encoder.layers) + len(self.model.decoder.layers)
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu, number_of_layers)
+        layer_ipu = get_layer_ipu(self.ipu_config, number_of_layers)
         for index, layer in enumerate(self.model.encoder.layers):
             ipu = layer_ipu[index]
             if self.ipu_config.recompute_checkpoint_every_layer and index != self.config.num_hidden_layers - 1:

--- a/optimum/graphcore/models/bert/modeling_bert.py
+++ b/optimum/graphcore/models/bert/modeling_bert.py
@@ -97,7 +97,7 @@ class PipelinedBertForPreTraining(BertForPreTraining, PipelineMixin):
         hs = outline_attribute(self.bert.embeddings.LayerNorm, "embeddings")
         self._hooks.extend(hs)
 
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu, self.bert.encoder.layer)
+        layer_ipu = get_layer_ipu(self.ipu_config, self.bert.encoder.layer)
         for index, layer in enumerate(self.bert.encoder.layer):
             ipu = layer_ipu[index]
             if self.ipu_config.recompute_checkpoint_every_layer:
@@ -269,7 +269,7 @@ class PipelinedBertForMaskedLM(BertForMaskedLM, PipelineMixin):
         hs = outline_attribute(self.bert.embeddings.LayerNorm, "embeddings")
         self._hooks.extend(hs)
 
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu, self.bert.encoder.layer)
+        layer_ipu = get_layer_ipu(self.ipu_config, self.bert.encoder.layer)
         for index, layer in enumerate(self.bert.encoder.layer):
             ipu = layer_ipu[index]
             if self.ipu_config.recompute_checkpoint_every_layer:
@@ -404,7 +404,7 @@ class BertPipelineMixin(PipelineMixin):
         hs = outline_attribute(self.bert.embeddings.LayerNorm, "embedding")
         self._hooks.extend(hs)
 
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu, self.bert.encoder.layer)
+        layer_ipu = get_layer_ipu(self.ipu_config, self.bert.encoder.layer)
         for index, layer in enumerate(self.bert.encoder.layer):
             ipu = layer_ipu[index]
             if self.ipu_config.recompute_checkpoint_every_layer and index != self.config.num_hidden_layers - 1:

--- a/optimum/graphcore/models/convnext/modeling_convnext.py
+++ b/optimum/graphcore/models/convnext/modeling_convnext.py
@@ -37,7 +37,8 @@ class PipelinedConvNextForImageClassification(ConvNextForImageClassification, Pi
         logger.info(f"Embedding  --> IPU 0")
         self.convnext.embeddings = poptorch.BeginBlock(self.convnext.embeddings, "Embedding", ipu_id=0)
 
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu)
+        num_encoder_layers = sum([len(stage.layers) for stage in self.convnext.encoder.stages])
+        layer_ipu = get_layer_ipu(self.ipu_config, num_encoder_layers)
         global_layer_idx = 0
         for stage_idx, stage in enumerate(self.convnext.encoder.stages):
             for layer_idx, layer in enumerate(stage.layers):

--- a/optimum/graphcore/models/deberta/modeling_deberta.py
+++ b/optimum/graphcore/models/deberta/modeling_deberta.py
@@ -330,7 +330,7 @@ class DebertaPipelineMixin(PipelineMixin):
         if self.deberta.encoder.relative_attention:
             self.deberta.encoder.rel_embeddings = poptorch.BeginBlock(self.deberta.encoder.rel_embeddings, ipu_id=0)
 
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu, self.deberta.encoder.layer)
+        layer_ipu = get_layer_ipu(self.ipu_config, self.deberta.encoder.layer)
         for index, layer in enumerate(self.deberta.encoder.layer):
             ipu = layer_ipu[index]
             if self.ipu_config.recompute_checkpoint_every_layer and index != self.config.num_hidden_layers - 1:

--- a/optimum/graphcore/models/distilbert/modeling_distilbert.py
+++ b/optimum/graphcore/models/distilbert/modeling_distilbert.py
@@ -137,7 +137,7 @@ class DistilBertPipelineMixin(PipelineMixin):
             )
         self.distilbert.embeddings = poptorch.BeginBlock(self.distilbert.embeddings, "Embedding", 0)
 
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu, self.distilbert.transformer.layer)
+        layer_ipu = get_layer_ipu(self.ipu_config, self.distilbert.transformer.layer)
         for index, layer in enumerate(self.distilbert.transformer.layer):
             ipu = layer_ipu[index]
             if self.ipu_config.recompute_checkpoint_every_layer and index != self.config.num_hidden_layers - 1:

--- a/optimum/graphcore/models/gpt2/modeling_gpt2.py
+++ b/optimum/graphcore/models/gpt2/modeling_gpt2.py
@@ -75,7 +75,7 @@ class GPT2PipelineMixin(PipelineMixin):
         hs = outline_attribute(self.transformer.ln_f, "LayerNorm")
         self._hooks.extend(hs)
 
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu, self.transformer.h)
+        layer_ipu = get_layer_ipu(self.ipu_config, self.transformer.h)
         for index, layer in enumerate(self.transformer.h):
             ipu = layer_ipu[index]
             if self.ipu_config.recompute_checkpoint_every_layer and index != self.config.num_hidden_layers - 1:
@@ -156,7 +156,7 @@ class PipelinedGPT2LMHeadModel(GPT2LMHeadModel, PipelineMixin, IPUGenerationMixi
         hs = outline_attribute(self.transformer.ln_f, "LayerNorm")
         self._hooks.extend(hs)
 
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu, self.transformer.h)
+        layer_ipu = get_layer_ipu(self.ipu_config, self.transformer.h)
         for index, layer in enumerate(self.transformer.h):
             ipu = layer_ipu[index]
             if self.ipu_config.recompute_checkpoint_every_layer:

--- a/optimum/graphcore/models/groupbert/modeling_groupbert.py
+++ b/optimum/graphcore/models/groupbert/modeling_groupbert.py
@@ -436,7 +436,7 @@ class PipelinedGroupBertForPreTraining(GroupBertForPreTraining, PipelineMixin):
             self.cls.predictions.decoder = serialized_decoder
             self.tie_weights()
 
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu)
+        layer_ipu = get_layer_ipu(self.ipu_config, self.bert.encoder.layer)
 
         logger.info("-------------------- Device Allocation --------------------")
         logger.info("Embedding --> IPU 0")
@@ -601,7 +601,7 @@ class PipelinedGroupBertForMaskedLM(GroupBertForMaskedLM, PipelineMixin):
             self.cls.predictions.decoder = serialized_decoder
             self.tie_weights()
 
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu)
+        layer_ipu = get_layer_ipu(self.ipu_config, self.bert.encoder.layer)
 
         logger.info("-------------------- Device Allocation --------------------")
         logger.info("Embedding  --> IPU 0")
@@ -726,7 +726,7 @@ class BertPipelineMixin(PipelineMixin):
         """
         super().parallelize()
 
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu)
+        layer_ipu = get_layer_ipu(self.ipu_config, self.bert.encoder.layer)
 
         logger.info("-------------------- Device Allocation --------------------")
         logger.info("Embedding --> IPU 0")

--- a/optimum/graphcore/models/hubert/modeling_hubert.py
+++ b/optimum/graphcore/models/hubert/modeling_hubert.py
@@ -47,7 +47,7 @@ class PipelinedHubertForSequenceClassification(HubertForSequenceClassification, 
         self.hubert.feature_projection = poptorch.BeginBlock(self.hubert.feature_projection, ipu_id=0)
         self.hubert.encoder = poptorch.BeginBlock(self.hubert.encoder, ipu_id=0)
 
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu, self.hubert.encoder.layers)
+        layer_ipu = get_layer_ipu(self.ipu_config, self.hubert.encoder.layers)
         for index, layer in enumerate(self.hubert.encoder.layers):
             # Put checkpoints on every encoder layer
             h = recomputation_checkpoint(layer)

--- a/optimum/graphcore/models/roberta/modeling_roberta.py
+++ b/optimum/graphcore/models/roberta/modeling_roberta.py
@@ -64,7 +64,7 @@ class RobertaPipelineMixin(PipelineMixin):
         hs = outline_attribute(self.roberta.embeddings.LayerNorm, "embedding")
         self._hooks.extend(hs)
 
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu, self.roberta.encoder.layer)
+        layer_ipu = get_layer_ipu(self.ipu_config, self.roberta.encoder.layer)
         for index, layer in enumerate(self.roberta.encoder.layer):
             ipu = layer_ipu[index]
             if self.ipu_config.recompute_checkpoint_every_layer and index != self.config.num_hidden_layers - 1:
@@ -129,7 +129,7 @@ class PipelinedRobertaForMaskedLM(RobertaForMaskedLM, PipelineMixin):
         hs = outline_attribute(self.roberta.embeddings.LayerNorm, "embedding")
         self._hooks.extend(hs)
 
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu, self.roberta.encoder.layer)
+        layer_ipu = get_layer_ipu(self.ipu_config, self.roberta.encoder.layer)
         for index, layer in enumerate(self.roberta.encoder.layer):
             ipu = layer_ipu[index]
             if self.ipu_config.recompute_checkpoint_every_layer:

--- a/optimum/graphcore/models/t5/modeling_t5.py
+++ b/optimum/graphcore/models/t5/modeling_t5.py
@@ -258,7 +258,7 @@ class PipelinedT5ForConditionalGeneration(T5ForConditionalGeneration, PipelineMi
             block.__class__ = CustomT5Block
 
         number_of_layers = len(self.encoder.block) + len(self.decoder.block)
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu, number_of_layers)
+        layer_ipu = get_layer_ipu(self.ipu_config, number_of_layers)
         for index, layer in enumerate(self.encoder.block):
             ipu = layer_ipu[index]
             if self.ipu_config.recompute_checkpoint_every_layer and index != self.config.num_layers - 1:

--- a/optimum/graphcore/models/vit/modeling_vit.py
+++ b/optimum/graphcore/models/vit/modeling_vit.py
@@ -30,7 +30,7 @@ class PipelinedViTForImageClassification(transformers.ViTForImageClassification,
         logger.info("Embedding  --> IPU 0")
         self.vit.embeddings = poptorch.BeginBlock(self.vit.embeddings, "Embedding", ipu_id=0)
 
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu, self.vit.encoder.layer)
+        layer_ipu = get_layer_ipu(self.ipu_config, self.vit.encoder.layer)
         for index, layer in enumerate(self.vit.encoder.layer):
             if self.ipu_config.recompute_checkpoint_every_layer:
                 # Put checkpoints on every encoder layer

--- a/optimum/graphcore/models/wav2vec2/modeling_wav2vec2.py
+++ b/optimum/graphcore/models/wav2vec2/modeling_wav2vec2.py
@@ -166,7 +166,7 @@ class PipelinedWav2Vec2ForPreTraining(Wav2Vec2ForPreTraining, PipelineMixin):
         # Project Quantizer
         layers.append(("Project Quantizer", self.project_q))
 
-        layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu, layers)
+        layer_ipu = get_layer_ipu(self.ipu_config, layers)
 
         for i, (name, layer) in enumerate(layers):
             logger.info(f"{name} --> IPU {layer_ipu[i]}")
@@ -448,7 +448,7 @@ class PipelinedWav2Vec2ForCTC(Wav2Vec2ForCTC, PipelineMixin):
             # Project Hidden
             layers.append(("Project Hidden", self.lm_head))
 
-            layer_ipu = get_layer_ipu(self.ipu_config.layers_per_ipu, layers)
+            layer_ipu = get_layer_ipu(self.ipu_config, layers)
 
             for i, (name, layer) in enumerate(layers):
                 logger.info(f"{name} --> IPU {layer_ipu[i]}")

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -610,6 +610,7 @@ class IPUTrainerIntegrationTest(TestCasePlus, IPUTrainerIntegrationCommon):
 
         ipu_config = get_ipu_config()
         ipu_config.layers_per_ipu = [3]
+        ipu_config.ipus_per_replica = 1
         ipu_config.gradient_accumulation_steps = 8
 
         trainer = IPUTrainer(tiny_gpt2, ipu_config, args, train_dataset=train_dataset)


### PR DESCRIPTION
Changes 
- `layers_per_ipu` to support wildcards (-1). Default value changed from [1] to [-1]. With this change, the `get_layer_ipu` method will use `ipus_per_replica` to fill in the `layers_per_ipu` if the wildcard is used. 
- If `ipus_per_replica` is 1, `layers_per_ipu` is ignored, and all layers are placed on IPU0. If `ipus_per_replica` > 1 and `layers_per_ipu` uses default value [-1] (or [-1] * `ipus_per_replica`), then the layers are evenly split over `ipus_per_replica` IPUs. 
- `layers_per_ipu` can support a combination of integers and wildcards e.g `[1, 1, -1, -1] will put 1 layer each on IPU0 and IPU1, and split the remaining layers evenly between IPU2 and IPU3. If there are an odd number of layers, the extra layer is placed on the last wildcard IPU. 
- Updated the docstring in the IPUConfig class

Tests
- Manually tested on the named-entity-extraction notebook, using different ipu_configs with different settings for `layers_per_ipu` and `ipus_per_replica`, to ensure the result is as expected. 
- Ran test_examples.py overnight, ensured all 30 tests passed. 