### PR TITLE
Infer `ipus_per_replica` from `layers_per_ipu`

### DIFF
--- a/examples/speech-recognition/run_inference_ctc.py
+++ b/examples/speech-recognition/run_inference_ctc.py
@@ -94,7 +94,6 @@ def main():
             matmul_proportion=0.1,
             inference_device_iterations=num_device_iterations,
             layers_per_ipu=[17, 16],
-            ipus_per_replica=2,
         )
     else:
         processor = Wav2Vec2Processor.from_pretrained("facebook/wav2vec2-base-960h")

--- a/optimum/graphcore/ipu_configuration.py
+++ b/optimum/graphcore/ipu_configuration.py
@@ -117,8 +117,8 @@ class IPUConfig(BaseConfig):
     def __init__(self, **kwargs):
         self.seed = kwargs.pop("seed", None)
 
-        self.ipus_per_replica = kwargs.pop("ipus_per_replica", 1)
         self.layers_per_ipu = kwargs.pop("layers_per_ipu", [1])
+        self.ipus_per_replica = kwargs.pop("ipus_per_replica", len(self.layers_per_ipu))
 
         self.replication_factor = kwargs.pop("replication_factor", 1)
         self.inference_replication_factor = kwargs.pop("inference_replication_factor", 1)

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -51,7 +51,6 @@ TINY_IPU_CONFIG_DICT = {
     "inference_device_iterations": 1,
     "inference_replication_factor": {"default": 1},
     "executable_cache_dir": "./exe_cache",
-    "ipus_per_replica": 2,
     "layers_per_ipu": [4, 5],
     "matmul_proportion": 0.25,
 }


### PR DESCRIPTION
# What does this PR do?

If the user were to parallelise a model themselves we make them provide `layers_per_ipu` and `ipus_per_replica`. However, `ipus_per_replica` is always just `len(layers_per_ipu)`. So I have made that the default behaviour. You can still provide it explicitly to override this if you need to.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

