### PR TITLE
Use buffers to cache the encoder hidden states in decoder wrapper

### DIFF
--- a/optimum/graphcore/generation_utils.py
+++ b/optimum/graphcore/generation_utils.py
@@ -43,10 +43,8 @@ from transformers.generation.utils import (
     SampleOutput,
     StoppingCriteriaList,
 )
-from transformers.modeling_outputs import ModelOutput, Seq2SeqLMOutput, BaseModelOutput
+from transformers.modeling_outputs import ModelOutput, BaseModelOutput
 from transformers.pytorch_utils import torch_int_div
-
-from poptorch import poptorch_core
 
 
 logger = logging.get_logger(__name__)
@@ -218,10 +216,11 @@ class DecoderWrapper(nn.Module):
     Only returns the logits from the last generated token to reduce IO costs.
     """
 
-    def __init__(self, pipelined_model, encoder_outputs, attention_mask):
+    def __init__(self, pipelined_model, encoder_outputs, attention_mask=None):
         super().__init__()
         self.pipelined_model = pipelined_model
-        self.register_buffer("encoder_attention_mask", attention_mask, persistent=False)
+        if attention_mask is not None:
+            self.register_buffer("encoder_attention_mask", attention_mask.half(), persistent=False)
         self.register_buffer("encoder_last_hidden_state", encoder_outputs.last_hidden_state, persistent=False)
 
         # With KV caching, some modules may need to know the current decoding step and beam indices.
@@ -269,7 +268,7 @@ class IPUGenerationMixin(GenerationMixin):
     def _call_generate(self, *args, generation_step: int, **kwargs):
         t = self._get_generation_step_tensor(generation_step)
         if not hasattr(self, "poptorch_decoder"):
-            wrapper = DecoderWrapper(self.eval(), kwargs["encoder_outputs"], kwargs["attention_mask"].half())
+            wrapper = DecoderWrapper(self.eval(), kwargs["encoder_outputs"], kwargs.get("attention_mask"))
             decoder_ipu_config = getattr(self, "decoder_ipu_config", self.ipu_config)
             if os.getenv("DEBUG_RUN_DECODER_ON_CPU", False):
                 self.poptorch_decoder = wrapper
@@ -279,7 +278,8 @@ class IPUGenerationMixin(GenerationMixin):
                 self.poptorch_decoder = poptorch.inferenceModel(wrapper, decoder_options)
         
         del kwargs["encoder_outputs"]
-        del kwargs["attention_mask"]
+        if kwargs.get("attention_mask") is not None:
+            del kwargs["attention_mask"]
 
         # This will trigger a compile first time it's ran
         with graph_profile_dir_append("/decoder" if self.config.is_encoder_decoder else ""):
@@ -292,7 +292,8 @@ class IPUGenerationMixin(GenerationMixin):
         if not self.config.is_encoder_decoder or not hasattr(self, "poptorch_decoder"):
             return
         self.poptorch_decoder.encoder_last_hidden_state.copy_(model_kwargs["encoder_outputs"]["last_hidden_state"])
-        self.poptorch_decoder.encoder_attention_mask.copy_(model_kwargs["attention_mask"].half())
+        if model_kwargs.get("attention_mask") is not None:
+            self.poptorch_decoder.encoder_attention_mask.copy_(model_kwargs["attention_mask"].half())
         self.poptorch_decoder.copyNamedBuffersToDevice()
 
     def _prepare_encoder_decoder_kwargs_for_generation(

--- a/optimum/graphcore/generation_utils.py
+++ b/optimum/graphcore/generation_utils.py
@@ -43,7 +43,7 @@ from transformers.generation.utils import (
     SampleOutput,
     StoppingCriteriaList,
 )
-from transformers.modeling_outputs import ModelOutput, BaseModelOutput
+from transformers.modeling_outputs import BaseModelOutput, ModelOutput
 from transformers.pytorch_utils import torch_int_div
 
 
@@ -284,7 +284,7 @@ class IPUGenerationMixin(GenerationMixin):
                     named_buffers.append("encoder_attention_mask")
                 decoder_options.updatableNamedBuffers(named_buffers)
                 self.poptorch_decoder = poptorch.inferenceModel(wrapper, decoder_options)
-        
+
         del kwargs["encoder_outputs"]
         if kwargs.get("attention_mask") is not None:
             del kwargs["attention_mask"]

--- a/optimum/graphcore/models/bart/modeling_bart.py
+++ b/optimum/graphcore/models/bart/modeling_bart.py
@@ -686,7 +686,7 @@ class _BartModelWithSharedEmbedding(BartModel):
 
 @register(BartForConditionalGeneration)
 class PipelinedBartForConditionalGeneration(BartForConditionalGeneration, PipelineMixin, IPUGenerationMixin):
-    def parallelize(self, for_generation=False):
+    def parallelize(self, for_generation=False, **kwargs):
         """
         Transform the model to run in an IPU pipeline.
         - Adds pipeline stages to the model
@@ -720,6 +720,7 @@ class PipelinedBartForConditionalGeneration(BartForConditionalGeneration, Pipeli
         self.model.change_bart_encoder_and_decoder_classes(False)
         self.model.change_bart_attention_class(False)
         self.change_lm_head_to_indexed_input_linear(restore=not for_generation)
+        self.use_encoder_output_buffer = kwargs.get("use_encoder_output_buffer", False)
 
         self.model.shared = poptorch.BeginBlock(self.model.shared, "Embedding", ipu_id=0)
         self.model.encoder.embed_positions = poptorch.BeginBlock(

--- a/optimum/graphcore/models/whisper/modeling_whisper.py
+++ b/optimum/graphcore/models/whisper/modeling_whisper.py
@@ -363,6 +363,8 @@ class PipelinedWhisperForConditionalGeneration(WhisperForConditionalGeneration, 
         self.change_decoder_positional_embedding(restore=False)
         self.change_attention_class(restore=False, use_cache=use_cache and for_generation, **kwargs)
         self.change_lm_head_to_indexed_input_linear(restore=use_cache or not for_generation)
+        self.use_encoder_output_buffer = kwargs.get("use_encoder_output_buffer", False)
+
 
         logger.info("---------- Device Allocation -----------")
         logger.info("conv1, conv2, embed_positions  --> IPU 0")

--- a/optimum/graphcore/models/whisper/modeling_whisper.py
+++ b/optimum/graphcore/models/whisper/modeling_whisper.py
@@ -365,7 +365,6 @@ class PipelinedWhisperForConditionalGeneration(WhisperForConditionalGeneration, 
         self.change_lm_head_to_indexed_input_linear(restore=use_cache or not for_generation)
         self.use_encoder_output_buffer = kwargs.get("use_encoder_output_buffer", False)
 
-
         logger.info("---------- Device Allocation -----------")
         logger.info("conv1, conv2, embed_positions  --> IPU 0")
         self.model.encoder.conv1 = poptorch.BeginBlock(self.model.encoder.conv1, "Conv1", ipu_id=0)


### PR DESCRIPTION
# What does this PR do?

POC using buffers to store the encoder hidden states in the decoder wrapper.
The current implementation copies all the weights and buffers every time the encoder is ran, so isn't efficient yet.


Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

