### PR TITLE
Fix encoder-decoder splitting for cases where ipus have 0 layers

### DIFF
--- a/optimum/graphcore/modeling_utils.py
+++ b/optimum/graphcore/modeling_utils.py
@@ -350,6 +350,9 @@ def split_encoder_decoder_ipu_config(
             f"\tipu_config.layers_per_ipu={ipu_config.layers_per_ipu}\n"
             f"\tnum_encoder_layers={num_encoder_layers}\n"
             f"\tnum_decoder_layers={num_decoder_layers}\n"
+            "Possible causes: \n"
+            "Encoder and decoder layers cannot be placed on the same IPUs.\n"
+            "The encoder and decoder layers_per_ipu splits each need a number of devices that's a power of 2."
         )
     ipu_configs["encoder"].layers_per_ipu = layers_per_ipu[:cut]
     ipu_configs["decoder"].layers_per_ipu = layers_per_ipu[cut:]

--- a/optimum/graphcore/modeling_utils.py
+++ b/optimum/graphcore/modeling_utils.py
@@ -341,7 +341,8 @@ def split_encoder_decoder_ipu_config(
     layers_per_ipu = _expand_layers_per_ipu_wildcard(ipu_config, num_encoder_layers + num_decoder_layers)
     cumsum = [sum(layers_per_ipu[: i + 1]) for i in range(len(layers_per_ipu))]
     try:
-        cut = [i + 1 for i, c in enumerate(cumsum) if c == num_encoder_layers][-1]
+        cut = [i + 1 for i, c in enumerate(cumsum) if c == num_encoder_layers]
+        cut = max([num for num in cut if num & (num - 1) == 0])
     except:
         raise IncompatibleIPUConfigError(
             f"Unable to find valid split of ipu_config.layers_per_ipu\n"

--- a/optimum/graphcore/modeling_utils.py
+++ b/optimum/graphcore/modeling_utils.py
@@ -342,6 +342,7 @@ def split_encoder_decoder_ipu_config(
     cumsum = [sum(layers_per_ipu[: i + 1]) for i in range(len(layers_per_ipu))]
     try:
         cut = [i + 1 for i, c in enumerate(cumsum) if c == num_encoder_layers]
+        # Choose the cut index that's the highest power of 2
         cut = max([num for num in cut if num & (num - 1) == 0])
     except:
         raise IncompatibleIPUConfigError(

--- a/tests/test_ipu_configuration.py
+++ b/tests/test_ipu_configuration.py
@@ -371,3 +371,19 @@ class IPUConfigTester(unittest.TestCase):
         self.assertEqual(e_ipu_config.ipus_per_replica, 4)
         self.assertEqual(d_ipu_config.layers_per_ipu, [5, 6, 7, 8])
         self.assertEqual(d_ipu_config.ipus_per_replica, 4)
+
+        # Split where first IPU has 0 layers
+        ipu_config = IPUConfig(layers_per_ipu=[0, 6, 0, 6])
+        e_ipu_config, d_ipu_config = split_encoder_decoder_ipu_config(ipu_config, 6, 6)
+        self.assertEqual(e_ipu_config.layers_per_ipu, [0, 6])
+        self.assertEqual(e_ipu_config.ipus_per_replica, 2)
+        self.assertEqual(d_ipu_config.layers_per_ipu, [0, 6])
+        self.assertEqual(d_ipu_config.ipus_per_replica, 2)
+
+        # Split where there are many zeros
+        ipu_config = IPUConfig(layers_per_ipu=[3, 0, 3, 0, 0, 7])
+        e_ipu_config, d_ipu_config = split_encoder_decoder_ipu_config(ipu_config, 6, 7)
+        self.assertEqual(e_ipu_config.layers_per_ipu, [3, 0, 3, 0])
+        self.assertEqual(e_ipu_config.ipus_per_replica, 4)
+        self.assertEqual(d_ipu_config.layers_per_ipu, [0, 7])
+        self.assertEqual(d_ipu_config.ipus_per_replica, 2)


### PR DESCRIPTION
# What does this PR do?

Fixes # (issue)

Now correctly splits cases where `layers_per_ipu` has 0s in it. Examples:
```
ipu_config = IPUConfig(layers_per_ipu=[1, 2, 3, 0, 5, 6, 7, 8]) -> [1, 2, 3, 0] / [5, 6, 7, 8]
ipu_config = IPUConfig(layers_per_ipu=[0, 6, 0, 6]) -> [0, 6] / [0, 6]
ipu_config = IPUConfig(layers_per_ipu=[3, 0, 3, 0, 0, 7]) -> [3, 0, 3, 0] / [0, 7]
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

