### PR TITLE
Fix when `POPLAR_ENGINE_OPTIONS` not for profiling

### DIFF
--- a/optimum/graphcore/generation_utils.py
+++ b/optimum/graphcore/generation_utils.py
@@ -51,15 +51,16 @@ logger = logging.get_logger(__name__)
 
 @contextlib.contextmanager
 def graph_profile_dir_append(append: str):
-    if poplar_engine_options := os.getenv("POPLAR_ENGINE_OPTIONS"):
-        poplar_engine_options_dict = json.loads(poplar_engine_options)
-        poplar_engine_options_dict["autoReport.directory"] += append
-        os.environ["POPLAR_ENGINE_OPTIONS"] = json.dumps(poplar_engine_options_dict)
+    if poplar_engine_options_original := os.getenv("POPLAR_ENGINE_OPTIONS"):
+        poplar_engine_options_modified = json.loads(poplar_engine_options_original)
+        if autoreport_directory := poplar_engine_options_modified.get("autoReport.directory"):
+            poplar_engine_options_modified["autoReport.directory"] = autoreport_directory + append
+            os.environ["POPLAR_ENGINE_OPTIONS"] = json.dumps(poplar_engine_options_modified)
     try:
         yield
     finally:
-        if poplar_engine_options:
-            os.environ["POPLAR_ENGINE_OPTIONS"] = poplar_engine_options
+        if poplar_engine_options_original:
+            os.environ["POPLAR_ENGINE_OPTIONS"] = poplar_engine_options_original
 
 
 class DecoderWrapper(nn.Module):


### PR DESCRIPTION
# What does this PR do?

This would fail if `POPLAR_ENGINE_OPTIONS` was used for purposes other than profiling. This PR fixes that.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

