### PR TITLE
Instantiate optimizer in compile only mode

### DIFF
--- a/optimum/graphcore/trainer.py
+++ b/optimum/graphcore/trainer.py
@@ -368,6 +368,7 @@ class IPUTrainer:
         if args.compile_only:
             logger.info("Called with compile_only=True. Compiling models then exiting.")
             if args.do_train:
+                self.optimizer = self.create_optimizer()
                 train_dl = self.get_train_dataloader()
                 model = self.wrap_model(self.model)
                 self.compile_model(model, next(iter(train_dl)), log=True)


### PR DESCRIPTION
# What does this PR do?

if the user does not provide an optimizer to the trainer class, `self.optimizer=None` with `compile only` mode. This is okay for `Trainer.train()` since it makes the call to `self.create_optimizer()`, which instantiates an optimizer if one does not exist. This PR ensures that an optimizer is instantiated even in compile only mode. 

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

