### PR TITLE
SerializedEmbedding: override default freeze=True on deserialization

### DIFF
--- a/optimum/graphcore/modeling_utils.py
+++ b/optimum/graphcore/modeling_utils.py
@@ -421,15 +421,18 @@ class SerializedEmbedding(nn.Module):
             ]
         )
 
-    def deserialize(self):
+    def deserialize(self, freeze=False):
         """
         Deserialize the internal wrapped embedding layer and return it as a
-        `nn.Embedding` object.
+        `nn.Embedding` object. Optionally override the default behaviour of
+        freezing embeddings when initialising from a tensor object.
 
         Returns:
             `nn.Embedding` layer
         """
-        return nn.Embedding.from_pretrained(torch.vstack([l.weight for l in self.split_embeddings]), padding_idx=0)
+        return nn.Embedding.from_pretrained(
+            torch.vstack([l.weight for l in self.split_embeddings]), padding_idx=0, freeze=freeze
+        )
 
     def forward(self, indices):
         # iterate through the splits

--- a/optimum/graphcore/modeling_utils.py
+++ b/optimum/graphcore/modeling_utils.py
@@ -410,7 +410,7 @@ class SerializedEmbedding(nn.Module):
         # Num embeddings should be divisible by the serialization factor
         assert self.num_embeddings % self.serialization_factor == 0
         self.split_size = self.num_embeddings // self.serialization_factor
-        
+
         freeze = not embedding.weight.requires_grad
         self.split_embeddings = nn.ModuleList(
             [
@@ -431,7 +431,7 @@ class SerializedEmbedding(nn.Module):
         Returns:
             `nn.Embedding` layer
         """
-        
+
         freeze = not self.split_embeddings[0].weight.requires_grad
         return nn.Embedding.from_pretrained(
             torch.vstack([l.weight for l in self.split_embeddings]), padding_idx=0, freeze=freeze


### PR DESCRIPTION
# What does this PR do?

The default behaviour of `nn.Embedding.from_pretrained` is to freeze the constructed embedding weights. This may not be what the user intends to do.  This PR overrides the default value and allows the user to optionally change the behaviour (for example in `pipelined_model_cls.deparallelize()`)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

