### PR TITLE
T5 revert fp16 clamping removal

### DIFF
--- a/optimum/graphcore/models/t5/modeling_t5.py
+++ b/optimum/graphcore/models/t5/modeling_t5.py
@@ -85,7 +85,11 @@ class CustomT5Block(T5Block):
         hidden_states, present_key_value_state = self_attention_outputs[:2]
         attention_outputs = self_attention_outputs[2:]  # Keep self-attention outputs and relative position weights
 
-        # Change: Remove check for inf and fp16 clamping
+        # clamp inf values to enable fp16 training
+        # Custom: Remove check for inf
+        if hidden_states.dtype == torch.float16:
+            clamp_value = torch.tensor(torch.finfo(hidden_states.dtype).max - 1000, dtype=hidden_states.dtype)
+            hidden_states = torch.clamp(hidden_states, min=-clamp_value, max=clamp_value)
 
         do_cross_attention = self.is_decoder and encoder_hidden_states is not None
         if do_cross_attention:
@@ -109,7 +113,11 @@ class CustomT5Block(T5Block):
             )
             hidden_states = cross_attention_outputs[0]
 
-            # Change: Remove check for inf and fp16 clamping
+            # clamp inf values to enable fp16 training
+            # Custom: Remove check for inf
+            if hidden_states.dtype == torch.float16:
+                clamp_value = torch.tensor(torch.finfo(hidden_states.dtype).max - 1000, dtype=hidden_states.dtype)
+                hidden_states = torch.clamp(hidden_states, min=-clamp_value, max=clamp_value)
 
             # Combine self attn and cross attn key value states
             if present_key_value_state is not None:
@@ -121,7 +129,11 @@ class CustomT5Block(T5Block):
         # Apply Feed Forward layer
         hidden_states = self.layer[-1](hidden_states)
 
-        # Change: Remove check for inf and fp16 clamping
+        # clamp inf values to enable fp16 training
+        # Custom: Remove check for inf
+        if hidden_states.dtype == torch.float16:
+            clamp_value = torch.tensor(torch.finfo(hidden_states.dtype).max - 1000, dtype=hidden_states.dtype)
+            hidden_states = torch.clamp(hidden_states, min=-clamp_value, max=clamp_value)
 
         outputs = (hidden_states,)
 


### PR DESCRIPTION
# What does this PR do?

- Clamps `inf` values in hidden state tensors to stabilise fp16 training

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

