### PR TITLE
Fix IPUSeq2SeqTrainer for models that have persistent buffers

### DIFF
--- a/optimum/graphcore/trainer_seq2seq.py
+++ b/optimum/graphcore/trainer_seq2seq.py
@@ -93,9 +93,9 @@ class IPUSeq2SeqTrainer(IPUTrainer):
         """
         self._max_length = max_length if max_length is not None else self.args.generation_max_length
         self._num_beams = num_beams if num_beams is not None else self.args.generation_num_beams
-        out = super().evaluate(eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
+        results = super().evaluate(eval_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
         self._rewrap_model_for_training()
-        return out
+        return results
 
     def predict(
         self,
@@ -144,9 +144,9 @@ class IPUSeq2SeqTrainer(IPUTrainer):
         """
         self._max_length = max_length if max_length is not None else self.args.generation_max_length
         self._num_beams = num_beams if num_beams is not None else self.args.generation_num_beams
-        out = super().predict(test_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
+        results = super().predict(test_dataset, ignore_keys=ignore_keys, metric_key_prefix=metric_key_prefix)
         self._rewrap_model_for_training()
-        return out
+        return results
 
     def prediction_step(
         self,

--- a/optimum/graphcore/trainer_seq2seq.py
+++ b/optimum/graphcore/trainer_seq2seq.py
@@ -20,10 +20,9 @@ from torch import nn
 from torch.utils.data import Dataset
 
 from optimum.utils import logging
+from poptorch._impl import rewrapModelIfNecessary, unwrapModelIfNecessary
 
 from .trainer import IPUTrainer
-
-from poptorch._impl import unwrapModelIfNecessary, rewrapModelIfNecessary
 
 
 logger = logging.get_logger(__name__)


### PR DESCRIPTION

# What does this PR do?
- unwrap poplar executor buffers before compiling an inference model for generation that has persistent buffers. Otherwise will raise an error stating that a persistent buffer does not have storage

Fixes # (issue)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

