### PR TITLE
Remove extra `parallelize` from `Trainer.__init__`

### DIFF
--- a/optimum/graphcore/trainer.py
+++ b/optimum/graphcore/trainer.py
@@ -291,7 +291,6 @@ class IPUTrainer:
                 self.eval_data_collator = data_collator_wrapper(self.eval_data_collator)
 
         self.model = to_pipelined(model, self.ipu_config, force=force_to_pipelined)
-        self.model.parallelize()
 
         self.original_model = model
 


### PR DESCRIPTION
# What does this PR do?

Fixes double parallelize issue introduced by #308 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

