### PR TITLE
Fix `test-pipelines.yml` and add host memory profiling to `RUN_SLOW=true` workflows

### DIFF
--- a/.github/workflows/test-general.yml
+++ b/.github/workflows/test-general.yml
@@ -32,6 +32,7 @@ jobs:
         export SDK_PATH=/opt/gc/poplar_sdk-ubuntu_20_04-3.2*
         pip install ${SDK_PATH}/poptorch-*.whl
         pip install .[testing]
+        pip install memory-profiler
     - name: Test with Pytest
       run: |
         source venv/bin/activate
@@ -39,11 +40,20 @@ jobs:
         . ${SDK_PATH}/poplar-ubuntu_20_04*/enable.sh
         . ${SDK_PATH}/popart-ubuntu_20_04*/enable.sh
         export POPTORCH_WAIT_FOR_IPU=1
-        pytest tests/ -n 16 --ignore=tests/pipelines/ --ignore=tests/test_examples_match_transformers.py
+        memprof run --interval 1 --include-children --multiprocess \
+          pytest tests/ -n 16 --ignore=tests/pipelines/ --ignore=tests/test_examples_match_transformers.py
+        memprof plot -o memory_profile.png
         pytest tests/test_examples_match_transformers.py
+    - name: Upload memory profile
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: memory_profile
+        path: memory_profile.png
     - name: Upload PopTorch error log if present
       if: always()
       uses: actions/upload-artifact@v3
       with:
         name: poptorch_error
         path: poptorch_error.log
+        if-no-files-found: ignore


### PR DESCRIPTION
# What does this PR do?

Since the tests are parallelised, you can have `n` models compiling at the same time. It's possible that this can cause the CI runner to use all available memory and start using swap, which slows the runner down dramatically.

This PR should prevent that from happening in `test-pipeliens.yml` and add some host memory monitoring so we can identify if it happens again in the future.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

