### PR TITLE
Add `--exit-code` to `mprof run` calls

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -42,7 +42,7 @@ jobs:
         . ${SDK_PATH}/poplar-ubuntu_20_04*/enable.sh
         . ${SDK_PATH}/popart-ubuntu_20_04*/enable.sh
         pytest tests/test_examples_match_transformers.py -v
-        mprof run --interval 1 --include-children --multiprocess \
+        mprof run --exit-code --interval 1 --include-children --multiprocess \
           pytest tests/test_examples.py -v -n 4
         mprof plot -o memory_profile.png
     - name: Upload memory profile

--- a/.github/workflows/test-pipelines.yml
+++ b/.github/workflows/test-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
         export SDK_PATH=/opt/gc/poplar_sdk-ubuntu_20_04-3.2*
         . ${SDK_PATH}/poplar-ubuntu_20_04*/enable.sh
         . ${SDK_PATH}/popart-ubuntu_20_04*/enable.sh
-        mprof run --interval 1 --include-children --multiprocess \
+        mprof run --exit-code --interval 1 --include-children --multiprocess \
           pytest tests/pipelines/ -v -n 4
         mprof plot -o memory_profile.png
     - name: Upload memory profile


### PR DESCRIPTION
# What does this PR do?

Stops `mprof run` from hiding `pytest` failures

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

