### PR TITLE
Deprecate modeless variants of attributes and type check attribute values 

### DIFF
--- a/examples/speech-recognition/run_inference_ctc.py
+++ b/examples/speech-recognition/run_inference_ctc.py
@@ -91,9 +91,9 @@ def main():
         processor = Wav2Vec2Processor.from_pretrained("facebook/wav2vec2-large-960h")
         model = AutoModelForCTC.from_pretrained("facebook/wav2vec2-large-960h")
         ipu_config = IPUConfig(
-            matmul_proportion=0.1,
+            training_matmul_proportion=0.1,
             inference_device_iterations=num_device_iterations,
-            layers_per_ipu=[17, 16],
+            training_layers_per_ipu=[17, 16],
         )
     else:
         processor = Wav2Vec2Processor.from_pretrained("facebook/wav2vec2-base-960h")

--- a/notebooks/stable_diffusion/stable_diffusion_space/ipu_models.py
+++ b/notebooks/stable_diffusion/stable_diffusion_space/ipu_models.py
@@ -113,8 +113,8 @@ class IPUStableDiffusionPipeline(StableDiffusionPipeline):
                 "executable_cache_dir": "./exe_cache",
                 "inference_device_iterations": 1,
                 "inference_replication_factor": {"default": 1},
-                "ipus_per_replica": 4,
-                "matmul_proportion": [0.09, 0.1, 0.1, 0.08],
+                "training_ipus_per_replica": 4,
+                "training_matmul_proportion": [0.09, 0.1, 0.1, 0.08],
             }
             if ipu_config is not None:
                 default_ipu_config_dict.update(ipu_config)

--- a/optimum/graphcore/diffusers/pipelines/stable_diffusion/ipu_configs.py
+++ b/optimum/graphcore/diffusers/pipelines/stable_diffusion/ipu_configs.py
@@ -20,46 +20,46 @@ INFERENCE_ENGINES_TO_MODEL_NAMES = {
 
 STABLE_DIFFUSION_V1_512_IPU_CONFIG = {
     "text_encoder": {
-        "ipus_per_replica": 1,
-        "matmul_proportion": 0.6,
+        "training_ipus_per_replica": 1,
+        "training_matmul_proportion": 0.6,
     },
     "unet": {
-        "ipus_per_replica": 4,
-        "matmul_proportion": [0.6, 0.6, 0.1, 0.3],
+        "training_ipus_per_replica": 4,
+        "training_matmul_proportion": [0.6, 0.6, 0.1, 0.3],
         "attn_matrix_target_mem_mb": 100,
     },
-    "vae": {"ipus_per_replica": 2, "matmul_proportion": 0.3},
-    "safety_checker": {"ipus_per_replica": 1, "matmul_proportion": 0.6},
+    "vae": {"training_ipus_per_replica": 2, "training_matmul_proportion": 0.3},
+    "safety_checker": {"training_ipus_per_replica": 1, "training_matmul_proportion": 0.6},
 }
 
 
 STABLE_DIFFUSION_V2_512_IPU_CONFIG = {
     "text_encoder": {
-        "ipus_per_replica": 1,
-        "matmul_proportion": 0.6,
+        "training_ipus_per_replica": 1,
+        "training_matmul_proportion": 0.6,
     },
     "unet": {
-        "ipus_per_replica": 4,
-        "matmul_proportion": [0.6, 0.6, 0.1, 0.3],
+        "training_ipus_per_replica": 4,
+        "training_matmul_proportion": [0.6, 0.6, 0.1, 0.3],
         "attn_matrix_target_mem_mb": 100,
     },
-    "vae": {"ipus_per_replica": 2, "matmul_proportion": 0.3},
-    "safety_checker": {"ipus_per_replica": 1, "matmul_proportion": 0.6},
+    "vae": {"training_ipus_per_replica": 2, "training_matmul_proportion": 0.3},
+    "safety_checker": {"training_ipus_per_replica": 1, "training_matmul_proportion": 0.6},
 }
 
 
 STABLE_DIFFUSION_V2_768_IPU_CONFIG = {
     "text_encoder": {
-        "ipus_per_replica": 1,
-        "matmul_proportion": 0.6,
+        "training_ipus_per_replica": 1,
+        "training_matmul_proportion": 0.6,
     },
     "unet": {
-        "ipus_per_replica": 4,
-        "matmul_proportion": [0.06, 0.1, 0.1, 0.1],
+        "training_ipus_per_replica": 4,
+        "training_matmul_proportion": [0.06, 0.1, 0.1, 0.1],
         "attn_matrix_target_mem_mb": 45,
     },
     "vae": None,  # not supported yet
-    "safety_checker": {"ipus_per_replica": 1, "matmul_proportion": 0.6},
+    "safety_checker": {"training_ipus_per_replica": 1, "training_matmul_proportion": 0.6},
 }
 
 

--- a/optimum/graphcore/ipu_configuration.py
+++ b/optimum/graphcore/ipu_configuration.py
@@ -17,9 +17,10 @@ import copy
 import json
 import warnings
 from tempfile import NamedTemporaryFile
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union, TypeVar, TypeAlias, List, Tuple
 
 import torch
+import typeguard
 
 import popart
 import poptorch
@@ -33,7 +34,11 @@ logger = logging.get_logger(__name__)
 IPU_CONFIG_NAME = "ipu_config.json"
 ALLOWED_POD_TYPES = ["pod4", "pod8", "pod16", "pod32", "pod64"]
 
-
+class IPUConfigAttributeTypes:
+    T = TypeVar("T")
+    Type: TypeAlias = Union[T, Dict[str, T]]
+    OptionalType =  Union[Optional[T], Dict[str, Optional[T]]]
+@typeguard.typechecked
 class IPUConfig(BaseConfig):
     """
     Class for PopArt and PopTorch configuration. Handles the conversion to poptorch options as well as configuration
@@ -66,15 +71,13 @@ class IPUConfig(BaseConfig):
         > Parameters related to parallelism
 
         layers_per_ipu (`List[int]`):
-            Specifies the number of layers that will be put on each IPU for pipelined execution.
+            Specifies the number of layers that will be put on each IPU for pipelined execution during training.
             For instance: `[2, 3, 4, 2]` specifies a 4-IPU pipeline, where the first two layers will be put on IPU0,
             the following three on IPU1, the next four on IPU2 and the last two on IPU3.
             If the default of [-1] is used, the layers will be split evenly over `ipus_per_replica` IPUs.
             The wildcard value '-1' can also be used in combination with integers.
             For instance: `[1, 2, -1, -1]` specifies a 4-IPU pipeline, where the first layer is put on IPU0,
             the next two layers on IPU1, and the remaining layers split evenly between IPU2 and IPU3.
-        training_layers_per_ipu (`List[int]`):
-            Same as `layers_per_ipu` for training only.
         inference_layers_per_ipu (`List[int]`):
             Same as `layers_per_ipu` for inference only.
 
@@ -85,14 +88,12 @@ class IPUConfig(BaseConfig):
         replicated_tensor_sharding (`bool`, *optional*, defaults to `False`):
             Shards the optimizer between replicas with zero-redundancy.
         matmul_proportion (`List[float]` or `float`, *optional*, defaults to 0.2):
-            Sets the amount of temporary memory made available on per-IPU basis.
+            Sets the amount of temporary memory made available on per-IPU basis during training.
             Use this setting to control the amount of temporary memory available to operations such as:
               - convolution
               - matrix multiplication
               - embedding lookups
               - indexing operations
-        training_matmul_proportion (`List[int]`):
-            Same as `matmul_proportion` for training only.
         inference_matmul_proportion (`List[int]`):
             Same as `matmul_proportion` for inference only.
         enable_half_partials (`bool`, *optional*, defaults to `True`):
@@ -124,8 +125,8 @@ class IPUConfig(BaseConfig):
 
     """
 
-    CONFIG_NAME = "ipu_config.json"
-    FULL_CONFIGURATION_FILE = "ipu_config.json"
+    CONFIG_NAME: str = "ipu_config.json"
+    FULL_CONFIGURATION_FILE: str = "ipu_config.json"
 
     class ManagedAttribute:
         def __init__(self, attr) -> None:
@@ -146,71 +147,123 @@ class IPUConfig(BaseConfig):
     # Create descriptor based managed attributes which will either return the
     # `training_` or `inference_` versions of the attribute depending on the value of
     # `self.mode` ("training" by default)
-    modes = ("training", "inference")
-    layers_per_ipu = ManagedAttribute("layers_per_ipu")
-    ipus_per_replica = ManagedAttribute("ipus_per_replica")
-    matmul_proportion = ManagedAttribute("matmul_proportion")
+    modes: Tuple[str] = ("training", "inference")
+    
+    layers_per_ipu = ManagedAttribute()
+    ipus_per_replica = ManagedAttribute()
+    matmul_proportion = ManagedAttribute()
+    replication_factor = ManagedAttribute()
+    device_iterations = ManagedAttribute()    
+    embedding_serialization_factor = ManagedAttribute()
+    linear_serialization_factor = ManagedAttribute()
+    serialized_embedding_splits_per_ipu = ManagedAttribute()
+    serialized_linear_splits_per_ipu = ManagedAttribute()
 
-    def __init__(self, **kwargs):
-        self.seed = kwargs.pop("seed", None)
-
+    def __init__(
+        self,
+        seed: IPUConfigAttributeTypes.OptionalType[int] = None,
+        auto_loss_scaling: IPUConfigAttributeTypes.Type[bool] = False,
+        executable_cache_dir : IPUConfigAttributeTypes.Type[str] = "",
+        replication_factor: IPUConfigAttributeTypes.Type[int] = 1,
+        inference_replication_factor: IPUConfigAttributeTypes.Type[int] = 1,
+        gradient_accumulation_steps : IPUConfigAttributeTypes.Type[int] = 1,
+        layers_per_ipu: IPUConfigAttributeTypes.Type[List[int]] = [-1],
+        inference_layers_per_ipu: IPUConfigAttributeTypes.OptionalType[List[int]] = None,
+        ipus_per_replica: IPUConfigAttributeTypes.OptionalType[int] = None,
+        inference_ipus_per_replica: IPUConfigAttributeTypes.OptionalType[int] = None,
+        optimizer_state_offchip : IPUConfigAttributeTypes.Type[bool] = True,
+        replicated_tensor_sharding: IPUConfigAttributeTypes.Type[bool] = False,
+        matmul_proportion: IPUConfigAttributeTypes.Type[Union[float, List[float]]] = 0.2,
+        inference_matmul_proportion: IPUConfigAttributeTypes.OptionalType[Union[float, List[float]]] = None,
+        enable_half_partials : IPUConfigAttributeTypes.Type[bool] = True,
+        embedding_serialization_factor: IPUConfigAttributeTypes.Type[int] = 1,
+        inference_embedding_serialization_factor: IPUConfigAttributeTypes.OptionalType[int] = None,
+        linear_serialization_factor: IPUConfigAttributeTypes.Type[int] = 1,
+        inference_linear_serialization_factor: IPUConfigAttributeTypes.OptionalType[int] = None,
+        serialized_linear_splits_per_ipu: IPUConfigAttributeTypes.OptionalType[List[int]] = None,
+        inference_serialized_linear_splits_per_ipu: IPUConfigAttributeTypes.OptionalType[List[int]] = None,
+        serialized_embedding_splits_per_ipu: IPUConfigAttributeTypes.OptionalType[List[int]] = None,
+        inference_serialized_embedding_splits_per_ipu: IPUConfigAttributeTypes.OptionalType[List[int]] = None,
+        recompute_checkpoint_every_layer : IPUConfigAttributeTypes.Type[bool] = True,
+        device_iterations : IPUConfigAttributeTypes.Type[int] = 1,
+        inference_device_iterations:  IPUConfigAttributeTypes.Type[int] = 1,
+        output_mode : IPUConfigAttributeTypes.Type[str] = "final",
+        execute_encoder_on_cpu_for_generation : IPUConfigAttributeTypes.Type[bool] = False,
+        **kwargs: Any        
+        ):
+        self.seed = seed
+        
         # Default mode to `training`
-        self.mode = "training"
+        self.train()
+        
+        self.layers_per_ipu = layers_per_ipu
+        self.inference_layers_per_ipu = inference_layers_per_ipu if inference_layers_per_ipu else layers_per_ipu
 
-        # Get execution mode agnostic arguments
-        layers_per_ipu = kwargs.pop("layers_per_ipu", [-1])
-        ipus_per_replica = kwargs.pop("ipus_per_replica", len(layers_per_ipu))
-        matmul_proportion = kwargs.pop("matmul_proportion", 0.2)
-
-        # Get execution mode specific arguments (if available)
-        for mode in self.modes:
-            setattr(self, f"{mode}_layers_per_ipu", kwargs.pop(f"{mode}_layers_per_ipu", layers_per_ipu))
-
-            # If ipus_per_replica is default, recalculate ipus_per_replica from {mode}_layers_per_ipu instead
-            if ipus_per_replica == len(layers_per_ipu):
-                ipus_per_replica = len(getattr(self, f"{mode}_layers_per_ipu"))
-            setattr(self, f"{mode}_ipus_per_replica", kwargs.pop(f"{mode}_ipus_per_replica", ipus_per_replica))
-
-            # If matmul_proportion is a list and its length is not equal to {mode}_ipus_per_replica, use the
-            # default float value for matmul_proportion instead
-            if (isinstance(matmul_proportion, list) and  # fmt: skip
-                len(matmul_proportion) != getattr(self, f"{mode}_ipus_per_replica")):  # fmt: skip
-                matmul_proportion = 0.2
-            setattr(self, f"{mode}_matmul_proportion", kwargs.pop(f"{mode}_matmul_proportion", matmul_proportion))
-
-        self.replication_factor = kwargs.pop("replication_factor", 1)
-        self.inference_replication_factor = kwargs.pop("inference_replication_factor", 1)
-        self.gradient_accumulation_steps = kwargs.pop("gradient_accumulation_steps", 1)
-        self.device_iterations = kwargs.pop("device_iterations", 1)
-        self.inference_device_iterations = kwargs.pop("inference_device_iterations", 1)
-        self.optimizer_state_offchip = kwargs.pop("optimizer_state_offchip", True)
-        self.replicated_tensor_sharding = kwargs.pop("replicated_tensor_sharding", False)
-        self.auto_loss_scaling = kwargs.pop("auto_loss_scaling", False)
-
+        # initialise `ipus_per_replica` using `layers_per_ipu` if it is None
+        self.ipus_per_replica = ipus_per_replica
+        if self.ipus_per_replica is None:
+            self.ipus_per_replica = len(self.layers_per_ipu)
+        
+        # If ipus_per_replica is default, recalculate inference_ipus_per_replica from inference_layers_per_ipu instead
+        self.inference_ipus_per_replica = inference_ipus_per_replica
+        if inference_ipus_per_replica is None:
+            self.inference_ipus_per_replica = len(self.inference_layers_per_ipu) if self.ipus_per_replica == self.layers_per_ipu else self.ipus_per_replica
+    
+        # If matmul_proportion is a list and its length is not equal to {mode}_ipus_per_replica, use the
+        # default float value for matmul_proportion instead
+        self.matmul_proportion = matmul_proportion
+        default_matmul_proportion = self.matmul_proportion
+        if isinstance(self.matmul_proportion, list) and len(self.matmul_proportion) != self.inference_ipus_per_replica:
+            default_matmul_proportion = 0.2 
+        self.inference_matmul_proportion = inference_matmul_proportion if inference_matmul_proportion else default_matmul_proportion
+        
+        self.embedding_serialization_factor = embedding_serialization_factor
+        self.inference_embedding_serialization_factor = inference_embedding_serialization_factor if inference_embedding_serialization_factor else embedding_serialization_factor
+        
+        self.linear_serialization_factor = linear_serialization_factor
+        self.inference_linear_serialization_factor = inference_linear_serialization_factor if inference_linear_serialization_factor else linear_serialization_factor
+        
+        self.serialized_embedding_splits_per_ipu = serialized_embedding_splits_per_ipu
+        self.inference_serialized_embedding_splits_per_ipu = inference_serialized_embedding_splits_per_ipu if inference_serialized_embedding_splits_per_ipu else serialized_embedding_splits_per_ipu
+        
+        self.serialized_linear_splits_per_ipu = serialized_linear_splits_per_ipu
+        self.inference_serialized_linear_splits_per_ipu = inference_serialized_linear_splits_per_ipu if inference_serialized_linear_splits_per_ipu else serialized_linear_splits_per_ipu
+        
+        self.replication_factor = replication_factor
+        self.inference_replication_factor = inference_replication_factor
+        self.gradient_accumulation_steps = gradient_accumulation_steps
+        self.device_iterations = device_iterations
+        self.inference_device_iterations = inference_device_iterations
+        self.optimizer_state_offchip = optimizer_state_offchip
+        self.replicated_tensor_sharding = replicated_tensor_sharding
+        self.auto_loss_scaling = auto_loss_scaling
+        
         if self.replicated_tensor_sharding and self.replication_factor == 1:
             logger.warning("Setting replicated_tensor_sharding to False when replication_factor=1")
             self.replicated_tensor_sharding = False
-
+            
         if "sharded_execution_for_inference" in kwargs:
             warnings.warn(
                 'The "sharded_execution_for_inference" parameter is deprecated, sharded execution is always used during inference'
             )
-
         if "enable_half_first_order_momentum" in kwargs:
             warnings.warn('The "enable_half_first_order_momentum" parameter is deprecated')
+        
+        self.enable_half_partials = enable_half_partials
+        self.executable_cache_dir = executable_cache_dir
+        self.recompute_checkpoint_every_layer = recompute_checkpoint_every_layer
+        self.output_mode = output_mode
+        #TODO: remove this if unnecessary
+        self.execute_encoder_on_cpu_for_generation = execute_encoder_on_cpu_for_generation
 
-        self.enable_half_partials = kwargs.pop("enable_half_partials", True)
-
-        self.executable_cache_dir = kwargs.pop("executable_cache_dir", "")
-
-        self.embedding_serialization_factor = kwargs.pop("embedding_serialization_factor", 1)
-
-        self.recompute_checkpoint_every_layer = kwargs.pop("recompute_checkpoint_every_layer", True)
-        self.output_mode = kwargs.pop("output_mode", "final")
-
-        # TODO: remove this if unnecessary.
-        self.execute_encoder_on_cpu_for_generation = kwargs.pop("execute_encoder_on_cpu_for_generation", False)
-
+    @property
+    def mode(self):
+        return self._mode
+    
+    @mode.setter
+    def mode(self, value):
+        raise NotImplementedError("Use the `train` and `eval` methods to set the ipu config mode instead.")  
+    
     def train(self):
         self.mode = "training"
         return self
@@ -406,6 +459,32 @@ class IPUConfig(BaseConfig):
             `poptorch.Options`: The option representing the `IPUConfig`.
         """
         return self.for_pod_type(pod_type)._to_options(for_inference=for_inference, compile_only=compile_only)
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Same as super().to_dict() but with the additional removal of private attributes 
+
+        Returns:
+            `Dict[str, Any]`: Dictionary of all the attributes that make up this configuration instance.
+        """
+        
+        original_mode = self.mode
+        
+        self.train()
+        output = super().to_dict()
+        
+        # revert private training attributes to match the public names
+        new_output = {}
+        prefix = "training_"
+        for attr_name, attr_value in output.items():
+            if attr_name.startswith(prefix):
+                new_output[attr_name[len(prefix):]] = attr_value
+            else:
+                new_output[attr_name] = attr_value
+                        
+        self._mode = original_mode
+        
+        return new_output
 
     def batch_size_factor(self, for_inference: bool = False, pod_type: Optional[str] = None) -> int:
         """

--- a/optimum/graphcore/ipu_configuration.py
+++ b/optimum/graphcore/ipu_configuration.py
@@ -17,16 +17,17 @@ import copy
 import json
 import warnings
 from tempfile import NamedTemporaryFile
-from typing import Any, Dict, Optional, Union, TypeVar, TypeAlias, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
 
 import torch
-import typeguard
 
 import popart
 import poptorch
+import typeguard
 from optimum.configuration_utils import BaseConfig
 from optimum.utils import logging
 from poptorch import Options, OutputMode
+from typing_extensions import TypeAlias
 
 
 logger = logging.get_logger(__name__)

--- a/optimum/graphcore/pipelines/__init__.py
+++ b/optimum/graphcore/pipelines/__init__.py
@@ -142,7 +142,7 @@ SUPPORTED_TASKS = {
         "class": (AutoModelForSeq2SeqLM,),
         "default": {
             "model": ("ainize/bart-base-cnn", "b90bc9a"),
-            "ipu_config": IPUConfig(ipus_per_replica=2),
+            "ipu_config": IPUConfig(training_ipus_per_replica=2),
             "max_input_length": 50,
             "max_length": 20,
             "truncation": "only_first",
@@ -155,7 +155,7 @@ SUPPORTED_TASKS = {
         "class": (AutoModelForSeq2SeqLM,),
         "default": {
             "model": ("t5-small", "9507060"),
-            "ipu_config": IPUConfig(ipus_per_replica=2),
+            "ipu_config": IPUConfig(training_ipus_per_replica=2),
             "max_length": 50,
             "max_input_length": 45,
             "truncation": "only_first",
@@ -167,7 +167,7 @@ SUPPORTED_TASKS = {
         "class": (AutoModelForSeq2SeqLM,),
         "default": {
             "model": ("t5-small", "9507060"),
-            "ipu_config": IPUConfig(ipus_per_replica=2),
+            "ipu_config": IPUConfig(training_ipus_per_replica=2),
             "max_length": 50,
             "max_input_length": 50,
             "truncation": "only_first",

--- a/optimum/graphcore/training_args.py
+++ b/optimum/graphcore/training_args.py
@@ -345,7 +345,7 @@ class IPUTrainingArguments:
             If `True`, the [`IPUTrainer`] will only perform model compilation and stop.
         ipu_config_overrides (`str`, *optional*):
             Overrides some existing IPU config settings.
-            Example: `device_iterations=4,gradient_accumulation_steps=64`
+            Example: `training_device_iterations=4,gradient_accumulation_steps=64`
         pad_on_batch_axis (`bool`, *optional*, defaults to `False`):
             Will pad each batch up to a fixed size. This ensures that the compiled model will have an input with the
             proper shape, and allows to not use `dataloader_drop_last` during training.
@@ -599,7 +599,7 @@ class IPUTrainingArguments:
     ipu_config_overrides: Optional[str] = field(
         default=None,
         metadata={
-            "help": "Override some existing ipu config settings. Example: device_iterations=4,gradient_accumulation_steps=64"
+            "help": "Override some existing ipu config settings. Example: training_device_iterations=4,gradient_accumulation_steps=64"
         },
     )
     pad_on_batch_axis: bool = field(

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ INSTALL_REQUIRES = [
     "diffusers[torch]==0.12.1",
     "datasets",
     "tokenizers",
+    "typeguard",
     "sentencepiece",
     "scipy",
     "pillow",

--- a/tests/ipu_config_trainer_test.json
+++ b/tests/ipu_config_trainer_test.json
@@ -1,9 +1,9 @@
 {
   "dataloader_workers": 64,
   "async_dataloader": true,
-  "ipus_per_replica": 4,
+  "training_ipus_per_replica": 4,
   "weight_decay": 0.0,
-  "embedding_serialization_factor": 1,
+  "training_embedding_serialization_factor": 1,
   "recompute_checkpoint_every_layer": true,
   "replicated_tensor_sharding": false,
   "optimizer_state_offchip": true,
@@ -12,9 +12,9 @@
   "attention_probs_dropout_prob": 0.0,
   "mask_tokens": 20,
   "output_mode": "all",
-  "replication_factor": 1,
+  "training_replication_factor": 1,
   "gradient_accumulation_steps": 1,
-  "device_iterations": 1,
+  "training_device_iterations": 1,
   "executable_cache_dir": "disabled",
   "replicated_tensor_sharding": true
 }

--- a/tests/pipelines/test_pipelines_automatic_speech_recognition.py
+++ b/tests/pipelines/test_pipelines_automatic_speech_recognition.py
@@ -51,8 +51,8 @@ TINY_IPU_CONFIG_DICT = {
     "inference_device_iterations": 1,
     "inference_replication_factor": {"default": 1},
     "executable_cache_dir": "./exe_cache",
-    "layers_per_ipu": [4, 5],
-    "matmul_proportion": 0.25,
+    "training_layers_per_ipu": [4, 5],
+    "training_matmul_proportion": 0.25,
 }
 
 

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -77,7 +77,7 @@ ROBERTA_EMBEDDING_ADJUSMENT_CONFIGS = [
     "XLMRobertaConfig",
 ]
 
-TINY_DISTILBERT_IPU_CONFIG = {"layers_per_ipu": [5], "ipus_per_replica": 1}
+TINY_DISTILBERT_IPU_CONFIG = {"training_layers_per_ipu": [5], "training_ipus_per_replica": 1}
 
 
 def get_supported_models(models_to_test, task_mapping, task="default"):

--- a/tests/pipelines/test_pipelines_fill_mask.py
+++ b/tests/pipelines/test_pipelines_fill_mask.py
@@ -30,7 +30,7 @@ class FillMaskPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta):
         unmasker = pipeline(
             task="fill-mask",
             model="sshleifer/tiny-distilroberta-base",
-            ipu_config={"layers_per_ipu": [2], "ipus_per_replica": 1},
+            ipu_config={"training_layers_per_ipu": [2], "training_ipus_per_replica": 1},
             top_k=2,
             framework="pt",
         )
@@ -100,7 +100,7 @@ class FillMaskPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta):
         unmasker = pipeline(
             task="fill-mask",
             model="distilroberta-base",
-            ipu_config={"layers_per_ipu": [6], "ipus_per_replica": 1},
+            ipu_config={"training_layers_per_ipu": [6], "training_ipus_per_replica": 1},
             top_k=2,
             framework="pt",
             fp16=False,

--- a/tests/pipelines/test_pipelines_image_classification.py
+++ b/tests/pipelines/test_pipelines_image_classification.py
@@ -111,7 +111,7 @@ class ImageClassificationPipelineTests(unittest.TestCase, metaclass=PipelineTest
         image_classifier = pipeline(
             "image-classification",
             model=small_model,
-            ipu_config={"layers_per_ipu": [5], "ipus_per_replica": 1},
+            ipu_config={"training_layers_per_ipu": [5], "training_ipus_per_replica": 1},
         )
 
         outputs = image_classifier("http://images.cocodataset.org/val2017/000000039769.jpg")
@@ -142,7 +142,7 @@ class ImageClassificationPipelineTests(unittest.TestCase, metaclass=PipelineTest
         image_classifier = pipeline(
             "image-classification",
             model="hf-internal-testing/tiny-random-vit",
-            ipu_config={"layers_per_ipu": [5], "ipus_per_replica": 1},
+            ipu_config={"training_layers_per_ipu": [5], "training_ipus_per_replica": 1},
             tokenizer=tokenizer,
         )
 

--- a/tests/pipelines/test_pipelines_question_answering.py
+++ b/tests/pipelines/test_pipelines_question_answering.py
@@ -117,7 +117,7 @@ class QAPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta):
         question_answerer = pipeline(
             "question-answering",
             model="sshleifer/tiny-distilbert-base-cased-distilled-squad",
-            ipu_config={"layers_per_ipu": [2], "ipus_per_replica": 1},
+            ipu_config={"training_layers_per_ipu": [2], "training_ipus_per_replica": 1},
         )
 
         outputs = question_answerer(
@@ -132,7 +132,7 @@ class QAPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta):
         pipe = pipeline(
             model="sshleifer/tiny-distilbert-base-cased-distilled-squad",
             batch_size=16,
-            ipu_config={"layers_per_ipu": [2], "ipus_per_replica": 1},
+            ipu_config={"training_layers_per_ipu": [2], "training_ipus_per_replica": 1},
         )
 
         def data():
@@ -147,7 +147,7 @@ class QAPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta):
         question_answerer = pipeline(
             "question-answering",
             model="sshleifer/tiny-distilbert-base-cased-distilled-squad",
-            ipu_config={"layers_per_ipu": [2], "ipus_per_replica": 1},
+            ipu_config={"training_layers_per_ipu": [2], "training_ipus_per_replica": 1},
         )
 
         real_postprocess = question_answerer.postprocess

--- a/tests/pipelines/test_pipelines_text_classification.py
+++ b/tests/pipelines/test_pipelines_text_classification.py
@@ -29,7 +29,7 @@ class TextClassificationPipelineTests(unittest.TestCase, metaclass=PipelineTestC
         text_classifier = pipeline(
             task="text-classification",
             model="hf-internal-testing/tiny-random-distilbert",
-            ipu_config={"layers_per_ipu": [5], "ipus_per_replica": 1},
+            ipu_config={"training_layers_per_ipu": [5], "training_ipus_per_replica": 1},
         )
 
         outputs = text_classifier("This is great !")

--- a/tests/pipelines/test_pipelines_token_classification.py
+++ b/tests/pipelines/test_pipelines_token_classification.py
@@ -421,7 +421,7 @@ class TokenClassificationPipelineTests(unittest.TestCase, metaclass=PipelineTest
     @require_torch
     def test_aggregation_strategy_no_b_i_prefix(self):
         model_name = "sshleifer/tiny-dbmdz-bert-large-cased-finetuned-conll03-english"
-        ipu_config = {"layers_per_ipu": [2], "ipus_per_replica": 1}
+        ipu_config = {"training_layers_per_ipu": [2], "training_ipus_per_replica": 1}
         tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=True)
         token_classifier = pipeline(
             task="ner",
@@ -480,7 +480,7 @@ class TokenClassificationPipelineTests(unittest.TestCase, metaclass=PipelineTest
     @require_torch
     def test_aggregation_strategy(self):
         model_name = "sshleifer/tiny-dbmdz-bert-large-cased-finetuned-conll03-english"
-        ipu_config = {"layers_per_ipu": [2], "ipus_per_replica": 1}
+        ipu_config = {"training_layers_per_ipu": [2], "training_ipus_per_replica": 1}
         tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=True)
         token_classifier = pipeline(
             task="ner",
@@ -563,7 +563,7 @@ class TokenClassificationPipelineTests(unittest.TestCase, metaclass=PipelineTest
     @require_torch
     def test_aggregation_strategy_example2(self):
         model_name = "sshleifer/tiny-dbmdz-bert-large-cased-finetuned-conll03-english"
-        ipu_config = {"layers_per_ipu": [2], "ipus_per_replica": 1}
+        ipu_config = {"training_layers_per_ipu": [2], "training_ipus_per_replica": 1}
         tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=True)
         token_classifier = pipeline(
             task="ner",
@@ -652,7 +652,7 @@ class TokenClassificationPipelineTests(unittest.TestCase, metaclass=PipelineTest
     @require_torch
     def test_gather_pre_entities(self):
         model_name = "sshleifer/tiny-dbmdz-bert-large-cased-finetuned-conll03-english"
-        ipu_config = {"layers_per_ipu": [2], "ipus_per_replica": 1}
+        ipu_config = {"training_layers_per_ipu": [2], "training_ipus_per_replica": 1}
         tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=True)
         token_classifier = pipeline(
             task="ner", model=model_name, ipu_config=ipu_config, tokenizer=tokenizer, framework="pt"
@@ -736,7 +736,7 @@ class TokenClassificationPipelineTests(unittest.TestCase, metaclass=PipelineTest
     @require_torch
     def test_no_offset_tokenizer(self):
         model_name = "hf-internal-testing/tiny-bert-for-token-classification"
-        ipu_config = {"layers_per_ipu": [2], "ipus_per_replica": 1}
+        ipu_config = {"training_layers_per_ipu": [2], "training_ipus_per_replica": 1}
         tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=False)
         token_classifier = pipeline(
             task="token-classification",
@@ -756,7 +756,7 @@ class TokenClassificationPipelineTests(unittest.TestCase, metaclass=PipelineTest
     @require_torch
     def test_small_model_pt(self):
         model_name = "hf-internal-testing/tiny-bert-for-token-classification"
-        ipu_config = {"layers_per_ipu": [2], "ipus_per_replica": 1}
+        ipu_config = {"training_layers_per_ipu": [2], "training_ipus_per_replica": 1}
         token_classifier = pipeline(
             task="token-classification",
             model=model_name,
@@ -820,7 +820,7 @@ class TokenClassificationPipelineTests(unittest.TestCase, metaclass=PipelineTest
     @require_torch
     def test_pt_ignore_subwords_slow_tokenizer_raises(self):
         model_name = "sshleifer/tiny-dbmdz-bert-large-cased-finetuned-conll03-english"
-        ipu_config = {"layers_per_ipu": [2], "ipus_per_replica": 1}
+        ipu_config = {"training_layers_per_ipu": [2], "training_ipus_per_replica": 1}
         tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=False)
 
         with self.assertRaises(ValueError):

--- a/tests/pipelines/test_pipelines_zero_shot.py
+++ b/tests/pipelines/test_pipelines_zero_shot.py
@@ -133,7 +133,7 @@ class ZeroShotClassificationPipelineTests(unittest.TestCase, metaclass=PipelineT
         zero_shot_classifier = pipeline(
             "zero-shot-classification",
             model="sshleifer/tiny-distilbert-base-cased-distilled-squad",
-            ipu_config={"layers_per_ipu": [2], "ipus_per_replica": 1},
+            ipu_config={"training_layers_per_ipu": [2], "training_ipus_per_replica": 1},
         )
         # There was a regression in 4.10 for this
         # Adding a test so we don't make the mistake again.
@@ -147,7 +147,7 @@ class ZeroShotClassificationPipelineTests(unittest.TestCase, metaclass=PipelineT
         zero_shot_classifier = pipeline(
             "zero-shot-classification",
             model="sshleifer/tiny-distilbert-base-cased-distilled-squad",
-            ipu_config={"layers_per_ipu": [2], "ipus_per_replica": 1},
+            ipu_config={"training_layers_per_ipu": [2], "training_ipus_per_replica": 1},
         )
         outputs = zero_shot_classifier(
             "Who are you voting for in 2020?", candidate_labels=["politics", "public health", "science"]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -259,7 +259,7 @@ class ExampleTesterBase(TestCase):
         ipu_config_overrides = ",".join(
             [
                 "executable_cache_dir=disabled",
-                "device_iterations=1",
+                "training_device_iterations=1",
                 f"inference_device_iterations={inference_device_iterations}",
                 f"gradient_accumulation_steps={gradient_accumulation_steps}",
             ]

--- a/tests/test_ipu_configuration.py
+++ b/tests/test_ipu_configuration.py
@@ -311,12 +311,15 @@ class IPUConfigTester(unittest.TestCase):
         ipu_config = IPUConfig(ipus_per_replica=0)
         with pytest.raises(IncompatibleIPUConfigError, match=r"Invalid value for ipus_per_replica"):
             layer_ipu = get_layer_ipu(ipu_config, 6)
+            
+    def test_type_check_attributes_construction(self):
+        
 
     def test_execution_mode_specific_options(self):
         ipu_config = IPUConfig(
-            training_layers_per_ipu=[1, 2, 3, 4],
-            training_matmul_proportion=[0.1, 0.2, 0.3, 0.4],
-            training_ipus_per_replica=4,
+            layers_per_ipu=[1, 2, 3, 4],
+            matmul_proportion=[0.1, 0.2, 0.3, 0.4],
+            ipus_per_replica=4,
             inference_layers_per_ipu=[3, 7],
             inference_matmul_proportion=[0.3, 0.7],
             inference_ipus_per_replica=2,
@@ -356,11 +359,11 @@ class IPUConfigTester(unittest.TestCase):
             ipu_config.layers_per_ipu = [1]
 
         # ipus_per_replica not specified
-        ipu_config = IPUConfig(training_layers_per_ipu=[1, 2, 3, 4])
+        ipu_config = IPUConfig(layers_per_ipu=[1, 2, 3, 4])
         self.assertEqual(ipu_config.ipus_per_replica, 4)
 
-        # training_layers_per_ipu wildcard
-        ipu_config = IPUConfig(ipus_per_replica=4, training_layers_per_ipu=[-1])
+        # layers_per_ipu wildcard
+        ipu_config = IPUConfig(ipus_per_replica=4, layers_per_ipu=[-1])
         layer_ipu = get_layer_ipu(ipu_config, 8)
         self.assertEqual(ipu_config.ipus_per_replica, 4)
         self.assertEqual(layer_ipu, [0, 0, 1, 1, 2, 2, 3, 3])
@@ -371,8 +374,8 @@ class IPUConfigTester(unittest.TestCase):
             matmul_proportion=[0.1, 0.2, 0.3, 0.4],
             inference_layers_per_ipu=[3, 7],
         )
-        self.assertEqual(ipu_config.training_layers_per_ipu, [1, 2, 3, 4])
-        self.assertEqual(ipu_config.training_matmul_proportion, [0.1, 0.2, 0.3, 0.4])
+        self.assertEqual(ipu_config.layers_per_ipu, [1, 2, 3, 4])
+        self.assertEqual(ipu_config.matmul_proportion, [0.1, 0.2, 0.3, 0.4])
         self.assertEqual(ipu_config.inference_matmul_proportion, 0.2)
 
     def test_split_encoder_decoder_ipu_config(self):

--- a/tests/test_ipu_configuration.py
+++ b/tests/test_ipu_configuration.py
@@ -311,9 +311,6 @@ class IPUConfigTester(unittest.TestCase):
         ipu_config = IPUConfig(ipus_per_replica=0)
         with pytest.raises(IncompatibleIPUConfigError, match=r"Invalid value for ipus_per_replica"):
             layer_ipu = get_layer_ipu(ipu_config, 6)
-            
-    def test_type_check_attributes_construction(self):
-        
 
     def test_execution_mode_specific_options(self):
         ipu_config = IPUConfig(

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -561,7 +561,7 @@ class IPUTrainerIntegrationTest(TestCasePlus, IPUTrainerIntegrationCommon):
         eval_dataset = RepeatDataset(x)
         args = IPUTrainingArguments("./test")
         ipu_config = get_ipu_config()
-        ipu_config.layers_per_ipu = [3, 0, 0, 0]
+        ipu_config.training_layers_per_ipu = [3, 0, 0, 0]
         trainer = IPUTrainer(tiny_gpt2, ipu_config, args, eval_dataset=eval_dataset)
         # By default the past_key_values are removed
         result = trainer.predict(eval_dataset)
@@ -609,8 +609,8 @@ class IPUTrainerIntegrationTest(TestCasePlus, IPUTrainerIntegrationCommon):
         args = IPUTrainingArguments("./test", learning_rate=1e9, logging_steps=5, logging_nan_inf_filter=False)
 
         ipu_config = get_ipu_config()
-        ipu_config.layers_per_ipu = [3]
-        ipu_config.ipus_per_replica = 1
+        ipu_config.training_layers_per_ipu = [3]
+        ipu_config.training_ipus_per_replica = 1
         ipu_config.gradient_accumulation_steps = 8
 
         trainer = IPUTrainer(tiny_gpt2, ipu_config, args, train_dataset=train_dataset)


### PR DESCRIPTION
# What does this PR do?

- Deprecate the use of `attribute` in favour of `training_attribute`, e.g. `device_iterations` -> `training_device_iterations`.  

- Internal redirection to training/inference attributes depending on the `IPUConfig.mode` still functions as introduced  [hereto](https://github.com/huggingface/optimum-graphcore/pull/308), however now the user only needs to be concerned with two parameters `{training, inference}_attribute` rather than three `{training, inference}_attribute` and the `attribute` parameter itself. 
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

