### PR TITLE
Skip equal check for denormals in known T5 layer

### DIFF
--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -791,7 +791,7 @@ class PipelineUtilsTest(unittest.TestCase):
         ):
             # For this specific layer in T5, check values that are <8 times the smallest normal number in fp16 less
             # strictly. This is because this layer is scaled down then up again by a factor of 8, turning these masked
-            # values into denormals, which we can no longer test for absolute equality.
+            # values into denormals, for which (x/8)*8 may not equal x.
             mask = torch.ones_like(cpu_param, dtype=torch.bool)
             if re.match(r"encoder\.block\.\d+\.layer\.1\.DenseReluDense\.wo\.weight", cpu_name):
                 mask = cpu_param >= 8 * torch.finfo(torch.float16).smallest_normal


### PR DESCRIPTION
# What does this PR do?

Fixes failing pipeline test coming from denormals in particular T5 layer.

To validate:

```
RUN_SLOW=true pytest -k test_load_default_pipelines_pt tests/pipelines/test_pipelines_common.py -v
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

