### PR TITLE
Only `parallelize(for_generation=True)` if pipeline task is in `SUPPORTED_GENERATION_TASKS`

### DIFF
--- a/optimum/graphcore/pipelines/__init__.py
+++ b/optimum/graphcore/pipelines/__init__.py
@@ -231,7 +231,7 @@ def get_poplar_executor(
     try:
         model = to_pipelined(model, ipu_config, force=False)
         if model.config.is_encoder_decoder and isinstance(model, IPUGenerationMixin):
-            model.parallelize(for_generation=True)
+            model.parallelize(for_generation=task in SUPPORTED_GENERATION_TASKS)
         else:
             model.parallelize()
     except Exception as error:

--- a/optimum/graphcore/pipelines/fill_mask.py
+++ b/optimum/graphcore/pipelines/fill_mask.py
@@ -29,3 +29,7 @@ class IPUFillMaskPipeline(FillMaskPipeline):
         model_inputs = self.tokenizer(inputs, return_tensors=return_tensors, **tokenizer_kwargs)
         self.ensure_exactly_one_mask_token(model_inputs)
         return model_inputs
+
+    def postprocess(self, model_outputs, top_k=5, target_ids=None):
+        model_outputs["logits"] = model_outputs["logits"].expand(-1, model_outputs["input_ids"].numel(), -1)
+        return super().postprocess(model_outputs, top_k, target_ids)

--- a/optimum/graphcore/pipelines/fill_mask.py
+++ b/optimum/graphcore/pipelines/fill_mask.py
@@ -29,7 +29,3 @@ class IPUFillMaskPipeline(FillMaskPipeline):
         model_inputs = self.tokenizer(inputs, return_tensors=return_tensors, **tokenizer_kwargs)
         self.ensure_exactly_one_mask_token(model_inputs)
         return model_inputs
-
-    def postprocess(self, model_outputs, top_k=5, target_ids=None):
-        model_outputs["logits"] = model_outputs["logits"].expand(-1, model_outputs["input_ids"].numel(), -1)
-        return super().postprocess(model_outputs, top_k, target_ids)

--- a/tests/pipelines/test_pipelines_fill_mask.py
+++ b/tests/pipelines/test_pipelines_fill_mask.py
@@ -167,18 +167,14 @@ class FillMaskPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta):
             ipu_config=ipu_config,
             tokenizer=tokenizer,
         )
-        examples = [
-            f"This is another {tokenizer.mask_token} test",
-        ]
+        examples = [f"This is a {tokenizer.mask_token} test"]
         return fill_masker, examples
 
     def run_pipeline_test(self, fill_masker, examples):
         tokenizer = fill_masker.tokenizer
         model = fill_masker.model
 
-        outputs = fill_masker(
-            f"This is a {tokenizer.mask_token}",
-        )
+        outputs = fill_masker(examples[0])
         self.assertEqual(
             outputs,
             [
@@ -190,7 +186,7 @@ class FillMaskPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta):
             ],
         )
 
-        outputs = fill_masker([f"This is a {tokenizer.mask_token}"])
+        outputs = fill_masker(examples)
         self.assertEqual(
             outputs,
             [
@@ -202,7 +198,7 @@ class FillMaskPipelineTests(unittest.TestCase, metaclass=PipelineTestCaseMeta):
             ],
         )
 
-        outputs = fill_masker([f"This is a {tokenizer.mask_token}", f"Another {tokenizer.mask_token} great test."])
+        outputs = fill_masker(examples * 2)
         self.assertEqual(
             outputs,
             [


### PR DESCRIPTION
# What does this PR do?

Fixes failing pipeline tests coming from index error in `fill-mask` pipeline

To validate:
```
RUN_SLOW=true pytest -k BartForConditionalGeneration tests/pipelines/test_pipelines_fill_mask.py -v
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

