### PR TITLE
Fixing links to API references

### DIFF
--- a/docs/source/add_support_for_new_model.mdx
+++ b/docs/source/add_support_for_new_model.mdx
@@ -20,10 +20,10 @@ To contribute and add support for a model architecture that is not currently sup
 
 1. Make sure the original model implementation inherits from `transformers.PreTrainedModel`. This is not 100% needed, but it is highly recommended to have access to all the features.
 2. Create a "pipelined" version of the original class. To do that:
-  - Inherit from both the original class and [`modeling_utils.PieplineMixin`]
-  - Implement the [`~modeling_utils.PipelineMixin.parallelize`] method, which specifies how each part of the model should be placed on the hardware.
-  - Implement the [`~modeling_utils.PipelineMixin.deparallize`] method, which takes a parallelized instance of the model back to its original version. This is needed to make sure that both the original and pipelined versions of the model can share the same state dictionary.
-3. Register the pipelined version of the class. This will enable the [`IPUTrainer`] class to automatically convert the original instance of a model to its pipelined counterpart.
+  - Inherit from both the original class and [`modeling_utils.PieplineMixin`](https://huggingface.co/docs/optimum/graphcore/add_support_for_new_model#optimum.graphcore.modeling_utils.PipelineMixin)
+  - Implement the [`~modeling_utils.PipelineMixin.parallelize`](https://huggingface.co/docs/optimum/graphcore/add_support_for_new_model#optimum.graphcore.modeling_utils.PipelineMixin.parallelize) method, which specifies how each part of the model should be placed on the hardware.
+  - Implement the [`~modeling_utils.PipelineMixin.deparallelize`](https://huggingface.co/docs/optimum/graphcore/add_support_for_new_model#optimum.graphcore.modeling_utils.PipelineMixin.deparallelize) method, which takes a parallelized instance of the model back to its original version. This is needed to make sure that both the original and pipelined versions of the model can share the same state dictionary.
+3. Register the pipelined version of the class. This will enable the [`IPUTrainer`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUTrainer) class to automatically convert the original instance of a model to its pipelined counterpart.
 
 **Example:** `transformers.ViTForImageClassification` to `PipelinedViTForImageClassification`
 

--- a/docs/source/add_support_for_new_model.mdx
+++ b/docs/source/add_support_for_new_model.mdx
@@ -20,7 +20,7 @@ To contribute and add support for a model architecture that is not currently sup
 
 1. Make sure the original model implementation inherits from `transformers.PreTrainedModel`. This is not 100% needed, but it is highly recommended to have access to all the features.
 2. Create a "pipelined" version of the original class. To do that:
-  - Inherit from both the original class and [`modeling_utils.PieplineMixin`](https://huggingface.co/docs/optimum/graphcore/add_support_for_new_model#optimum.graphcore.modeling_utils.PipelineMixin)
+  - Inherit from both the original class and [`modeling_utils.PipelineMixin`](https://huggingface.co/docs/optimum/graphcore/add_support_for_new_model#optimum.graphcore.modeling_utils.PipelineMixin)
   - Implement the [`~modeling_utils.PipelineMixin.parallelize`](https://huggingface.co/docs/optimum/graphcore/add_support_for_new_model#optimum.graphcore.modeling_utils.PipelineMixin.parallelize) method, which specifies how each part of the model should be placed on the hardware.
   - Implement the [`~modeling_utils.PipelineMixin.deparallelize`](https://huggingface.co/docs/optimum/graphcore/add_support_for_new_model#optimum.graphcore.modeling_utils.PipelineMixin.deparallelize) method, which takes a parallelized instance of the model back to its original version. This is needed to make sure that both the original and pipelined versions of the model can share the same state dictionary.
 3. Register the pipelined version of the class. This will enable the [`IPUTrainer`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUTrainer) class to automatically convert the original instance of a model to its pipelined counterpart.

--- a/docs/source/diffusers.mdx
+++ b/docs/source/diffusers.mdx
@@ -24,7 +24,7 @@ A few [🤗 diffusers](https://huggingface.co/docs/diffusers/index) have been ad
 
 ## API reference
 
-### IPUStableDiffusionPipeline
+### IPUStableDiffusionPipeline class
 
 This class is based on the [🤗 StableDiffusionPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/text2img) pipeline.
 
@@ -33,7 +33,7 @@ Run the following notebooks to see how this pipeline is used:
 * [Stable Diffusion Text-to-Image Generation on IPUs](https://github.com/huggingface/optimum-graphcore/blob/main/notebooks/stable_diffusion/text_to_image.ipynb)
 * [Text-to-Image Generation on IPUs using Stable Diffusion 2.0 - Inference](https://github.com/huggingface/optimum-graphcore/blob/main/notebooks/stable_diffusion/text_to_image_sd2.ipynb)
 
-### IPUStableDiffusionImg2ImgPipeline
+### IPUStableDiffusionImg2ImgPipeline class
 
 This class is based on the [🤗 StableDiffusionImg2ImgPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/img2img) pipeline.
 
@@ -42,7 +42,7 @@ Run the [Stable Diffusion Image-to-Image Generation on IPUs](https://github.com/
 [[autodoc]] diffusers.IPUStableDiffusionImg2ImgPipeline
   - all
 
-### IPUStableDiffusionInpaintPipeline
+### IPUStableDiffusionInpaintPipeline class
 
 Based on the [🤗 StableDiffusionInpaintPipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/inpaint) pipeline.
 

--- a/docs/source/diffusers.mdx
+++ b/docs/source/diffusers.mdx
@@ -18,9 +18,9 @@ limitations under the License.
 
 A few [🤗 diffusers](https://huggingface.co/docs/diffusers/index) have been adapted for use with IPUs. The available IPU diffusers are:
 
-* [IPUStableDiffusionPipeline](#IPUStableDiffusionPipeline)
-* [IPUStableDiffusionImg2ImgPipeline](#IPUStableDiffusionImg2ImgPipeline)
-* [IPUStableDiffusionInpaintPipeline](#IPUStableDiffusionInpaintPipeline)
+* [`IPUStableDiffusionPipeline`](https://huggingface.co/docs/optimum/graphcore/diffusers#optimum.graphcore.diffusers.IPUStableDiffusionPipeline)
+* [`IPUStableDiffusionImg2ImgPipeline`](https://huggingface.co/docs/optimum/graphcore/diffusers#optimum.graphcore.diffusers.IPUStableDiffusionImg2ImgPipeline)
+* [`IPUStableDiffusionInpaintPipeline`](https://huggingface.co/docs/optimum/graphcore/diffusers#optimum.graphcore.diffusers.IPUStableDiffusionInpaintPipeline)
 
 ## API reference
 

--- a/docs/source/ipu_config.mdx
+++ b/docs/source/ipu_config.mdx
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Configuration
 
-The [`IPUConfig`] class enables defining configuration for PopArt and for PyTorch for the IPU, allowing to control the behavior of the IPUs. It is JSON-serializable, and can be loaded from and saved to a local directory or file, as well as from and to the 🤗 Hub.
+The [`IPUConfig`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUConfig) class enables defining configuration for PopArt and for PyTorch for the IPU, allowing to control the behavior of the IPUs. It is JSON-serializable, and can be loaded from and saved to a local directory or file, as well as from and to the 🤗 Hub.
 
 ## Examples of use
 

--- a/docs/source/ipu_config.mdx
+++ b/docs/source/ipu_config.mdx
@@ -46,6 +46,6 @@ ipu_config = IPUConfig.from_pretrained(
 
 ## API reference
 
-### IPUConfig
+### IPUConfig class
 
 [[autodoc]] IPUConfig

--- a/docs/source/ipu_config.mdx
+++ b/docs/source/ipu_config.mdx
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Configuration
 
-The [`IPUConfig`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUConfig) class enables defining configuration for PopArt and for PyTorch for the IPU, allowing to control the behavior of the IPUs. It is JSON-serializable, and can be loaded from and saved to a local directory or file, as well as from and to the 🤗 Hub.
+The [`IPUConfig`](https://huggingface.co/docs/optimum/graphcore/ipu_config#optimum.graphcore.IPUConfig) class enables defining configuration for PopArt and for PyTorch for the IPU, allowing to control the behavior of the IPUs. It is JSON-serializable, and can be loaded from and saved to a local directory or file, as well as from and to the 🤗 Hub.
 
 ## Examples of use
 

--- a/docs/source/pipelines.mdx
+++ b/docs/source/pipelines.mdx
@@ -18,12 +18,12 @@ limitations under the License.
 
 There are a number of [🤗 pipelines](https://huggingface.co/docs/transformers/main_classes/pipelines) that have been adapted for use with IPUs. The available IPU pipelines are:
 
-* [`IPUFillMaskPipeline`]
-* [`IPUText2TextGenerationPipeline`]
-* [`IPUSummarizationPipeline`]
-* [`IPUTranslationPipeline`]
-* [`IPUTokenClassificationPipeline`]
-* [`IPUZeroShotClassificationPipeline`]
+* [`IPUFillMaskPipeline`](https://huggingface.co/docs/optimum/graphcore/pipelines#optimum.graphcore.IPUFillMaskPipeline)
+* [`IPUText2TextGenerationPipeline`](https://huggingface.co/docs/optimum/graphcore/pipelines#optimum.graphcore.pipelines.IPUText2TextGenerationPipeline)
+* [`IPUSummarizationPipeline`](https://huggingface.co/docs/optimum/graphcore/pipelines#optimum.graphcore.pipelines.IPUSummarizationPipeline)
+* [`IPUTranslationPipeline`](https://huggingface.co/docs/optimum/graphcore/pipelines#optimum.graphcore.pipelines.IPUTranslationPipeline)
+* [`IPUTokenClassificationPipeline`](https://huggingface.co/docs/optimum/graphcore/pipelines#optimum.graphcore.IPUTokenClassificationPipeline)
+* [`IPUZeroShotClassificationPipeline`](https://huggingface.co/docs/optimum/graphcore/pipelines#optimum.graphcore.pipelines.IPUZeroShotClassificationPipeline)
 
 ## API reference
 

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -46,11 +46,11 @@ We have a range of example scripts in [`/examples`](https://github.com/huggingfa
 
 The main Optimum Graphcore classes are:
 
-- [`IPUTrainer`]: This class handles compiling the model to run on IPUs, as well as performing the training and evaluation. Refer to the [`IPUTrainer`](trainer) section for more information.
-- [`IPUConfig`]: This class specifies attributes and configuration parameters to compile and put the model on the IPU. Refer to the [`IPUConfig`](ipu_config) section for more information.
+- [`IPUTrainer`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUTrainer): This class handles compiling the model to run on IPUs, as well as performing the training and evaluation. Refer to the section on [training](trainer) for more information.
+- [`IPUConfig`]: This class specifies attributes and configuration parameters to compile and put the model on the IPU. Refer to the section on [configuration](ipu_config) section for more information.
 
 
-[`IPUTrainer`] is very similar to the 🤗 Transformers [Trainer](https://huggingface.co/docs/transformers/main_classes/trainer) class, and you can easily adapt a script that currently uses `Trainer` to make it work with IPUs. You will mostly swap `Trainer` for [`IPUTrainer`]. This is how most of the [Optimum Graphcore example scripts](https://github.com/huggingface/optimum-graphcore/tree/main/examples) were adapted from the [original Hugging Face](https://github.com/huggingface/transformers/tree/master/examples/pytorch) scripts.
+[`IPUTrainer`] is very similar to the 🤗 Transformers [Trainer](https://huggingface.co/docs/transformers/main_classes/trainer) class, and you can easily adapt a script that currently uses `Trainer` to make it work with IPUs. You will mostly swap `Trainer` for [`IPUTrainer`]((https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUTrainer)). This is how most of the [Optimum Graphcore example scripts](https://github.com/huggingface/optimum-graphcore/tree/main/examples) were adapted from the [original Hugging Face](https://github.com/huggingface/transformers/tree/master/examples/pytorch) scripts.
 
 ```diff
 -from transformers import Trainer, TrainingArguments

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -47,10 +47,10 @@ We have a range of example scripts in [`/examples`](https://github.com/huggingfa
 The main Optimum Graphcore classes are:
 
 - [`IPUTrainer`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUTrainer): This class handles compiling the model to run on IPUs, as well as performing the training and evaluation. Refer to the section on [training](trainer) for more information.
-- [`IPUConfig`]: This class specifies attributes and configuration parameters to compile and put the model on the IPU. Refer to the section on [configuration](ipu_config) section for more information.
+- [`IPUConfig`](https://huggingface.co/docs/optimum/graphcore/ipu_config#optimum.graphcore.IPUConfig): This class specifies attributes and configuration parameters to compile and put the model on the IPU. Refer to the section on [configuration](ipu_config) section for more information.
 
 
-[`IPUTrainer`] is very similar to the 🤗 Transformers [Trainer](https://huggingface.co/docs/transformers/main_classes/trainer) class, and you can easily adapt a script that currently uses `Trainer` to make it work with IPUs. You will mostly swap `Trainer` for [`IPUTrainer`]((https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUTrainer)). This is how most of the [Optimum Graphcore example scripts](https://github.com/huggingface/optimum-graphcore/tree/main/examples) were adapted from the [original Hugging Face](https://github.com/huggingface/transformers/tree/master/examples/pytorch) scripts.
+[`IPUTrainer`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUTrainer) is very similar to the 🤗 Transformers [Trainer](https://huggingface.co/docs/transformers/main_classes/trainer) class, and you can easily adapt a script that currently uses `Trainer` to make it work with IPUs. You will mostly swap `Trainer` for [`IPUTrainer`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUTrainer). This is how most of the [Optimum Graphcore example scripts](https://github.com/huggingface/optimum-graphcore/tree/main/examples) were adapted from the [original Hugging Face](https://github.com/huggingface/transformers/tree/master/examples/pytorch) scripts.
 
 ```diff
 -from transformers import Trainer, TrainingArguments

--- a/docs/source/trainer.mdx
+++ b/docs/source/trainer.mdx
@@ -16,15 +16,15 @@ limitations under the License.
 
 # Training, Evaluation and Prediction
 
-The [`IPUTrainer`] class provides a similar API to the 🤗 Transformers [Trainer](https://huggingface.co/docs/transformers/main_classes/trainer) class to perform training, evaluation and prediction on Graphcore's IPUs. It is the class used in all the [example scripts](https://github.com/huggingface/optimum-graphcore/tree/main/examples).
+The [`IPUTrainer`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUTrainer) class provides a similar API to the 🤗 Transformers [Trainer](https://huggingface.co/docs/transformers/main_classes/trainer) class to perform training, evaluation and prediction on Graphcore's IPUs. It is the class used in all the [example scripts](https://github.com/huggingface/optimum-graphcore/tree/main/examples).
 
-Compared to the 🤗 Transformers [Trainer](https://huggingface.co/docs/transformers/main_classes/trainer) class, to instantiate [`IPUTrainer`] you need to create:
-  - An instance of [`IPUTrainingArguments`], which allows you to customize the behaviour of the trainer
-  - An instance of [`IPUConfig`], which defines IPU-specific parameters
+Compared to the 🤗 Transformers [Trainer](https://huggingface.co/docs/transformers/main_classes/trainer) class, to instantiate [`IPUTrainer`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUTrainer) you need to create:
+  - An instance of [`IPUTrainingArguments`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUTrainingArguments), which allows you to customize the behaviour of the trainer
+  - An instance of [`IPUConfig`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUConfig), which defines IPU-specific parameters
 
-There is an equivalent [`IPUSeq2SeqTrainer`] class for seq2seq models which requires you to define:
-  - An instance of [`IPUSeq2SeqTrainingArguments`]
-  - An instance of [`IPUConfig`]
+There is an equivalent [`IPUSeq2SeqTrainer`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUSeq2SeqTrainer) class for seq2seq models which requires you to define:
+  - An instance of [`IPUSeq2SeqTrainingArguments`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUSeq2SeqTrainingArguments)
+  - An instance of [`IPUConfig`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUConfig)
 
 ## Examples of use
 

--- a/docs/source/trainer.mdx
+++ b/docs/source/trainer.mdx
@@ -20,11 +20,11 @@ The [`IPUTrainer`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum
 
 Compared to the 🤗 Transformers [Trainer](https://huggingface.co/docs/transformers/main_classes/trainer) class, to instantiate [`IPUTrainer`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUTrainer) you need to create:
   - An instance of [`IPUTrainingArguments`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUTrainingArguments), which allows you to customize the behaviour of the trainer
-  - An instance of [`IPUConfig`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUConfig), which defines IPU-specific parameters
+  - An instance of [`IPUConfig`](https://huggingface.co/docs/optimum/graphcore/ipu_config#optimum.graphcore.IPUConfig), which defines IPU-specific parameters
 
 There is an equivalent [`IPUSeq2SeqTrainer`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUSeq2SeqTrainer) class for seq2seq models which requires you to define:
   - An instance of [`IPUSeq2SeqTrainingArguments`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUSeq2SeqTrainingArguments)
-  - An instance of [`IPUConfig`](https://huggingface.co/docs/optimum/graphcore/trainer#optimum.graphcore.IPUConfig)
+  - An instance of [`IPUConfig`](https://huggingface.co/docs/optimum/graphcore/ipu_config#optimum.graphcore.IPUConfig)
 
 ## Examples of use
 


### PR DESCRIPTION
# What does this PR do?

The links to API references that are auto-generated do not have the correct base URL. This PR manually adds links to the API references. 

Example of autogenerated link: https://huggingface.co/docs/optimum.graphcore/main/en/add_support_for_new_model#optimum.graphcore.modeling_utils.PipelineMixin.parallelize

Actual (correct) link: https://huggingface.co/docs/optimum/graphcore/add_support_for_new_model#optimum.graphcore.modeling_utils.PipelineMixin.parallelize