### PR TITLE
Offline compilation for pipelines

### DIFF
--- a/optimum/graphcore/pipelines/__init__.py
+++ b/optimum/graphcore/pipelines/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from typing import Any, List, Optional, Union
-
+import copy
 import torch
 
 import poptorch
@@ -492,8 +492,9 @@ def pipeline(
             pipeline_clone.model = model.compile
             try:
                 pipeline_clone.__call__(*inputs, **kwargs)
-            except:
+            except TypeError:
                 pass
+
         else:
             self.__call__(*inputs, **kwargs)
 

--- a/optimum/graphcore/pipelines/__init__.py
+++ b/optimum/graphcore/pipelines/__init__.py
@@ -366,7 +366,6 @@ def pipeline(
     if ipu_config is None and not isinstance(model, poptorch._poplar_executor.PoplarExecutor):
         ipu_config = SUPPORTED_TASKS[targeted_task]["default"]["ipu_config"]
 
-    cpu_model = model
     if model is None:
         model_id, revision = SUPPORTED_TASKS[targeted_task]["default"]["model"]
         logger.warning(

--- a/optimum/graphcore/pipelines/__init__.py
+++ b/optimum/graphcore/pipelines/__init__.py
@@ -15,10 +15,8 @@
 from typing import Any, List, Optional, Union
 
 import torch
-import copy
 
 import poptorch
-from poptorch import enums
 import transformers.pipelines
 from optimum.graphcore.generation.utils import IPUGenerationMixin
 from optimum.graphcore.ipu_configuration import IncompatibleIPUConfigError, IPUConfig
@@ -487,7 +485,6 @@ def pipeline(
 
         if offline_compilation:
             print("Using offline compilation")
-            # make a clone to not alter the original poplarExecutor
             pipeline_clone = pipeline(*initial_state[:-1], **initial_state[-1])
             options = copy.deepcopy(self.model._options)
             options.useOfflineIpuTarget()


### PR DESCRIPTION
# What does this PR do?
Add a .compile method for pipelines with the key-word argument 'offline' to also allow offline compilation 
This would be very useful for deployment :  Allowing user to pre-compile the model locally without IPUs, build their own containers and deploy it later.

example:

```
question_answerer = pipeline(
            "question-answering", model="distilbert-base-cased-distilled-squad"
        )
dummy_inputs_dict = {
            "question": "What is your name?",
            "context": "My name is Rob.",
        }

question_answerer.compile(dummy_inputs_dict, offline=True)
```