### PR TITLE
Add `padding_idx` to appropriate embedding split

### DIFF
--- a/optimum/graphcore/modeling_utils.py
+++ b/optimum/graphcore/modeling_utils.py
@@ -476,7 +476,7 @@ class SerializedEmbedding(nn.Module):
                 nn.Embedding.from_pretrained(
                     embedding.weight[i * self.split_size : (i + 1) * self.split_size, :].detach(),
                     freeze=freeze,
-                    padding_idx=self.padding_idx
+                    padding_idx=self.padding_idx - i * self.split_size
                     if i == torch.bucketize(self.padding_idx, boundaries).item()
                     else None,
                 )

--- a/optimum/graphcore/modeling_utils.py
+++ b/optimum/graphcore/modeling_utils.py
@@ -477,7 +477,7 @@ class SerializedEmbedding(nn.Module):
                     embedding.weight[i * self.split_size : (i + 1) * self.split_size, :].detach(),
                     freeze=freeze,
                     padding_idx=self.padding_idx - i * self.split_size
-                    if i == torch.bucketize(self.padding_idx, boundaries).item()
+                    if self.padding_idx and i == torch.bucketize(self.padding_idx, boundaries).item()
                     else None,
                 )
                 for i in range(self.serialization_factor)

--- a/optimum/graphcore/modeling_utils.py
+++ b/optimum/graphcore/modeling_utils.py
@@ -468,12 +468,13 @@ class SerializedEmbedding(nn.Module):
 
         freeze = not embedding.weight.requires_grad
         self.padding_idx = embedding.padding_idx
+        boundaries = torch.linspace(self.split_size-1, self.num_embeddings-1, self.serialization_factor, dtype=torch.int)
         self.split_embeddings = nn.ModuleList(
             [
                 nn.Embedding.from_pretrained(
                     embedding.weight[i * self.split_size : (i + 1) * self.split_size, :].detach(),
                     freeze=freeze,
-                    padding_idx=embedding.padding_idx if i == 0 else None,
+                    padding_idx=self.padding_idx if i == torch.bucketize(self.padding_idx, boundaries).item() else None,
                 )
                 for i in range(self.serialization_factor)
             ]

--- a/optimum/graphcore/modeling_utils.py
+++ b/optimum/graphcore/modeling_utils.py
@@ -468,13 +468,17 @@ class SerializedEmbedding(nn.Module):
 
         freeze = not embedding.weight.requires_grad
         self.padding_idx = embedding.padding_idx
-        boundaries = torch.linspace(self.split_size-1, self.num_embeddings-1, self.serialization_factor, dtype=torch.int)
+        boundaries = torch.linspace(
+            self.split_size - 1, self.num_embeddings - 1, self.serialization_factor, dtype=torch.int
+        )
         self.split_embeddings = nn.ModuleList(
             [
                 nn.Embedding.from_pretrained(
                     embedding.weight[i * self.split_size : (i + 1) * self.split_size, :].detach(),
                     freeze=freeze,
-                    padding_idx=self.padding_idx if i == torch.bucketize(self.padding_idx, boundaries).item() else None,
+                    padding_idx=self.padding_idx
+                    if i == torch.bucketize(self.padding_idx, boundaries).item()
+                    else None,
                 )
                 for i in range(self.serialization_factor)
             ]

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -163,3 +163,9 @@ class SerializedEmbeddingTester(unittest.TestCase, SerializedLayerTester):
             other_evaluator = PytorchEvaluator(serialized_embedding)
 
         return evaluator, other_evaluator, dataset
+
+    @parameterized.expand(((1, 0, 1), (63, 3, 15)))
+    def test_padding_idx(self, padding_idx, split, expected_padding_idx):
+        embedding = torch.nn.Embedding(num_embeddings=64, embedding_dim=8, padding_idx=padding_idx)
+        serialized_embedding = SerializedEmbedding.from_model(embedding, 4)
+        assert serialized_embedding.split_embeddings[split].padding_idx == expected_padding_idx


### PR DESCRIPTION
# What does this PR do?

Fixes bug in `SerializedEmbedding` where it is assumed that the `padding_idx` will be on the 0th embedding split

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

