### PR TITLE
Fix issue where exe cache dir was set too late

### DIFF
--- a/notebooks/flan_t5_inference.ipynb
+++ b/notebooks/flan_t5_inference.ipynb
@@ -132,16 +132,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from optimum.graphcore import pipeline\n",
+    "from optimum.graphcore import pipeline, IPUConfig\n",
     "\n",
     "size = {4: \"large\", 16: \"xl\"}\n",
     "flan_t5 = pipeline(\n",
     "    \"text2text-generation\",\n",
     "    model=f\"google/flan-t5-{size[num_available_ipus]}\",\n",
-    "    ipu_config=f\"Graphcore/t5-{size[num_available_ipus]}-ipu\",\n",
+    "    ipu_config=IPUConfig.from_pretrained(\n",
+    "        f\"Graphcore/t5-{size[num_available_ipus]}-ipu\",\n",
+    "        executable_cache_dir=executable_cache_dir,\n",
+    "    ),\n",
     "    max_input_length=896,\n",
-    ")\n",
-    "flan_t5.model.ipu_config.executable_cache_dir = executable_cache_dir"
+    ")"
    ]
   },
   {


### PR DESCRIPTION
# What does this PR do?

`executable_cache_dir` is fixed during `pipeline` construction because `pipeline.__init__()` creates the poplar executor

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

