### PR TITLE
Only use hard coded `ipus_per_replica` if `layers_per_ipu` is default

### DIFF
--- a/optimum/graphcore/ipu_configuration.py
+++ b/optimum/graphcore/ipu_configuration.py
@@ -331,7 +331,7 @@ class IPUConfig(BaseConfig):
         self.layers_per_ipu = layers_per_ipu
         self.inference_layers_per_ipu = inference_layers_per_ipu if inference_layers_per_ipu else self.layers_per_ipu
 
-        self.ipus_per_replica = ipus_per_replica if ipus_per_replica else len(self.layers_per_ipu)
+        self.ipus_per_replica = ipus_per_replica if ipus_per_replica and layers_per_ipu == [-1] else len(self.layers_per_ipu)
         # If ipus_per_replica is default, recalculate ipus_per_replica from inference_layers_per_ipu instead
         fallback_ipus_per_replica = self.ipus_per_replica
         if fallback_ipus_per_replica == len(self.layers_per_ipu) or self.inference_layers_per_ipu != [-1]:

--- a/optimum/graphcore/ipu_configuration.py
+++ b/optimum/graphcore/ipu_configuration.py
@@ -331,7 +331,9 @@ class IPUConfig(BaseConfig):
         self.layers_per_ipu = layers_per_ipu
         self.inference_layers_per_ipu = inference_layers_per_ipu if inference_layers_per_ipu else self.layers_per_ipu
 
-        self.ipus_per_replica = ipus_per_replica if ipus_per_replica and layers_per_ipu == [-1] else len(self.layers_per_ipu)
+        self.ipus_per_replica = (
+            ipus_per_replica if ipus_per_replica and layers_per_ipu == [-1] else len(self.layers_per_ipu)
+        )
         # If ipus_per_replica is default, recalculate ipus_per_replica from inference_layers_per_ipu instead
         fallback_ipus_per_replica = self.ipus_per_replica
         if fallback_ipus_per_replica == len(self.layers_per_ipu) or self.inference_layers_per_ipu != [-1]:

--- a/optimum/graphcore/modeling_utils.py
+++ b/optimum/graphcore/modeling_utils.py
@@ -262,7 +262,7 @@ def _expand_layers_per_ipu_wildcard(
 
             elif len(layers_per_ipu) != ipus_per_replica:
                 raise IncompatibleIPUConfigError(
-                    f"{layers_per_ipu_mode_str} has a non-default value set, but its length does not match {ipus_per_replica_mode_str}"
+                    f"{layers_per_ipu_mode_str} has a non-default value set, but its length does not match {ipus_per_replica_mode_str}. "
                     f"{layers_per_ipu_mode_str}={layers_per_ipu}, {ipus_per_replica_mode_str}={ipus_per_replica}. "
                 )
             # no wildcards used


### PR DESCRIPTION
# What does this PR do?

Stops manual overrides of `layers_per_ipu` throwing errors when `ipus_per_replica` was not also updated

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

