### PR TITLE
Add support for `whisper-small` fine-tuning

### DIFF
--- a/optimum/graphcore/models/whisper/modeling_whisper.py
+++ b/optimum/graphcore/models/whisper/modeling_whisper.py
@@ -553,6 +553,9 @@ class PipelinedWhisperForConditionalGeneration(WhisperForConditionalGeneration, 
         if (serialized_projection_splits_per_ipu := self.ipu_config._serialized_projection_splits_per_ipu) is not None:
             serialized_projection_ipus = [i for i, x in enumerate(serialized_projection_splits_per_ipu) if x]
             if len(serialized_projection_ipus) > 1:
+                # This is because we are using SerializedLinear. All splits of a SerializedLinear layer must be on the
+                # same IPU. We are using SerializedLinear instead of SplitLinear because we must tie the weights, which
+                # cannot be done when using SplitLinear.
                 raise ValueError(
                     "`serialized_projection_splits_per_ipu` must only have 1 non-zero element for Whisper."
                 )

--- a/optimum/graphcore/models/whisper/modeling_whisper.py
+++ b/optimum/graphcore/models/whisper/modeling_whisper.py
@@ -478,7 +478,7 @@ class PipelinedWhisperForConditionalGeneration(WhisperForConditionalGeneration, 
                 self.tie_weights()
         else:
             projection_serialization_factor = max(
-                self.ipu_config._projection_serialization_factor,
+                self.ipu_config._projection_serialization_factor or 1,
                 sum(self.ipu_config._serialized_projection_splits_per_ipu or [1]),
             )
             if projection_serialization_factor > 1:

--- a/optimum/graphcore/models/whisper/modeling_whisper.py
+++ b/optimum/graphcore/models/whisper/modeling_whisper.py
@@ -551,7 +551,12 @@ class PipelinedWhisperForConditionalGeneration(WhisperForConditionalGeneration, 
 
         decoder_embedding_ipu = decoder_layer_ipu[0]
         if (serialized_projection_splits_per_ipu := self.ipu_config._serialized_projection_splits_per_ipu) is not None:
-            decoder_embedding_ipu = [i for i, x in enumerate(serialized_projection_splits_per_ipu) if x][0]
+            serialized_projection_ipus = [i for i, x in enumerate(serialized_projection_splits_per_ipu) if x]
+            if len(serialized_projection_ipus) > 1:
+                raise ValueError(
+                    "`serialized_projection_splits_per_ipu` must only have 1 non-zero element for Whisper."
+                )
+            decoder_embedding_ipu = serialized_projection_ipus[0]
         self.model.decoder.embed_tokens = poptorch.BeginBlock(
             self.model.decoder.embed_tokens, "Decoder Embedding", ipu_id=decoder_embedding_ipu
         )


### PR DESCRIPTION
# What does this PR do?

Allows the user to specify which IPU the decoder projection resides on using `serialized_projection_splits_per_ipu`.

Also requires modifications to the IPUConfig in order to compile correctly, but these are still WIP so I won't post here.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

