### PR TITLE
Add back source optimum graphcore install in embeddings notebook

### DIFF
--- a/notebooks/text_embeddings_models/text-embeddings-on-ipu.ipynb
+++ b/notebooks/text_embeddings_models/text-embeddings-on-ipu.ipynb
@@ -40,7 +40,7 @@
    "outputs": [],
    "source": [
     "# Install Optimum Graphcore if it is not in your environment\n",
-    "# ! pip install git+https://github.com/huggingface/optimum-graphcore.git \n",
+    "! pip install git+https://github.com/huggingface/optimum-graphcore.git \n",
     "\n",
     "! pip install sentence-transformers==2.2.2"
    ]


### PR DESCRIPTION
Add back the commented `optimum-graphcore` source install in the notebook - now changes to source have landed.
