### PR TITLE
Make notebook titles consistent

### DIFF
--- a/notebooks/image_classification.ipynb
+++ b/notebooks/image_classification.ipynb
@@ -7,7 +7,7 @@
     "id": "pdcMxVGEA9Cd"
    },
    "source": [
-    "# Image Classification on IPUs using ViT - Fine-tuning\n",
+    "# Image Classification on IPU with ViT - Fine-tuning\n",
     "\n",
     "In this notebook, we will see how to fine-tune one of the [🤗 Transformers](https://github.com/huggingface/transformers) vision models on an image classification dataset.\n",
     "\n",

--- a/notebooks/introduction_to_optimum_graphcore.ipynb
+++ b/notebooks/introduction_to_optimum_graphcore.ipynb
@@ -6,7 +6,7 @@
    "id": "86c80779",
    "metadata": {},
    "source": [
-    "# Introduction to  🤗  Optimum Graphcore: BERT Fine-tuning on IPUs\n",
+    "# Introduction to 🤗 Optimum Graphcore: BERT-Large Fine-tuning on IPU\n",
     "\n",
     "<p align=\"center\">\n",
     "    <img src=\"https://github.com/huggingface/optimum-graphcore/blob/main/readme_logo.png?raw=true\" />\n",

--- a/notebooks/multiple_choice.ipynb
+++ b/notebooks/multiple_choice.ipynb
@@ -7,7 +7,7 @@
     "id": "rEJBSTyZIrIb"
    },
    "source": [
-    "# Multiple Choice on IPUs - Fine-tuning"
+    "# Multiple choice on IPU using RoBERTa - Fine-tuning"
    ]
   },
   {

--- a/notebooks/name-entity-extraction.ipynb
+++ b/notebooks/name-entity-extraction.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Real-Time Name Entity Recognition on the IPU\n",
+    "# Named Entity Recognition on IPU using BERT - Inference\n",
     "\n",
     "Integration of the Graphcore Intelligence Processing Unit (IPU) and the [🤗 Transformers library](https://huggingface.co/docs/transformers/index) means that it only takes a few lines of code to perform complex tasks which require deep learning.\n",
     "\n",

--- a/notebooks/packed_bert/packedBERT_multi_label_text_classification.ipynb
+++ b/notebooks/packed_bert/packedBERT_multi_label_text_classification.ipynb
@@ -7,7 +7,7 @@
     "id": "rEJBSTyZIrIb"
    },
    "source": [
-    "# Faster Multi-label Text Classification using PackedBERT on IPUs"
+    "# Faster Multi-label Text Classification on IPU with Packed BERT - Fine-tuning and Inference"
    ]
   },
   {

--- a/notebooks/packed_bert/packedBERT_question_answering.ipynb
+++ b/notebooks/packed_bert/packedBERT_question_answering.ipynb
@@ -6,7 +6,7 @@
    "id": "156ed6e4",
    "metadata": {},
    "source": [
-    "# Faster Question Answering with SQuAD using PackedBERT on IPUs\n",
+    "# Faster Question-answering on IPU using Packed BERT - Fine-tuning and Inference\n",
     "\n",
     "This notebook describes how to fine-tune BERT from [🤗 Transformers](https://github.com/huggingface/transformers) for question answering using the SQuAD(v1) dataset using [packing](https://towardsdatascience.com/introducing-packed-bert-for-2x-faster-training-in-natural-language-processing-eadb749962b1), an optimisation method originally used for 2x faster BERT pre-training, which can now also provide massive throughput increases for fine-tuning and batched inference! \n",
     "\n",

--- a/notebooks/packed_bert/packedBERT_single_label_text_classification.ipynb
+++ b/notebooks/packed_bert/packedBERT_single_label_text_classification.ipynb
@@ -7,8 +7,7 @@
     "id": "rEJBSTyZIrIb"
    },
    "source": [
-    "# Faster Single-label Text Classification using PackedBERT on IPUs\n",
-    "\n",
+    "# Faster single-label text classification on IPU with Packed BERT - Fine-tuning and Inference\n",
     "This notebook builds on the process in the notebook on [fine-tuning BERT on a text classification task](text_classification.ipynb) and uses [packing](https://www.graphcore.ai/posts/introducing-packed-bert-for-2x-faster-training-in-natural-language-processing), an optimisation method originally used for 2x faster BERT pre-training, which can now also provide massive throughput increases for fine-tuning and batched inference! \n",
     "\n",
     "**So, what *is* packing?** The basic idea of \"packing\" a dataset is to utilise the requirement for constant-shaped inputs into a model. Instead of padding it with empty, unused space, we can recycle this unused space and fill it with more inputs! The architecture of transformer models like BERT supports this, and lets us optimally use this space to process multiple sequences within one input.\n",

--- a/notebooks/question_answering.ipynb
+++ b/notebooks/question_answering.ipynb
@@ -7,7 +7,7 @@
     "id": "rEJBSTyZIrIb"
    },
    "source": [
-    "# Question Answering on IPUs - Fine-tuning"
+    "# Question-Answering on IPU using RoBERTa - Fine-tuning"
    ]
   },
   {

--- a/notebooks/sentiment_analysis.ipynb
+++ b/notebooks/sentiment_analysis.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Fast Sentiment Analysis on IPUs using Pre-trained Models\n",
+    "# Text Classification for Sentiment Analysis on IPU using Multiple NLP Models - Inference\n",
     "\n",
     "Integration of the Graphcore Intelligence Processing Unit (IPU) and the [🤗 Transformers library](https://huggingface.co/docs/transformers/index) means that it only takes a few lines of code to perform complex tasks which require deep learning.\n",
     "\n",

--- a/notebooks/stable_diffusion/image_to_image.ipynb
+++ b/notebooks/stable_diffusion/image_to_image.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Stable Diffusion Image-to-Image Generation on IPUs\n",
+    "# Image-to-Image Generation on IPU using Stable Diffusion - Inference\n",
     "\n",
     "This notebook demonstrates how a stable diffusion inference pipeline can be run on Graphcore IPUs. Stable Diffusion is a latent text-to-image diffusion model capable of generating photo-realistic images defined by text input. In this notebook, we demonstrate how Stable Diffusion can be used to update an input image based on a text prompt.\n",
     "\n",

--- a/notebooks/stable_diffusion/text_to_image.ipynb
+++ b/notebooks/stable_diffusion/text_to_image.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Stable Diffusion Text-to-Image Generation on IPUs\n",
+    "# Text-to-Image Generation on IPU with Stable Diffusion - Inference\n",
     "\n",
     "This notebook demonstrates how a Stable Diffusion inference pipeline can be run on Graphcore IPUs. Stable Diffusion is a latent text-to-image diffusion model capable of generating photo-realistic images defined by text input. \n",
     "\n",

--- a/notebooks/summarization.ipynb
+++ b/notebooks/summarization.ipynb
@@ -7,7 +7,7 @@
     "id": "rEJBSTyZIrIb"
    },
    "source": [
-    "# Summarization on IPUs - Fine-tuning"
+    "# Summarization on IPU using T5 Small - Fine-tuning"
    ]
   },
   {

--- a/notebooks/text_classification.ipynb
+++ b/notebooks/text_classification.ipynb
@@ -7,7 +7,7 @@
     "id": "rEJBSTyZIrIb"
    },
    "source": [
-    "# Text Classification on IPUs - Fine-tuning"
+    "# Text Classification Task on IPU using RoBERTa - Fine-tuning"
    ]
   },
   {

--- a/notebooks/token_classification.ipynb
+++ b/notebooks/token_classification.ipynb
@@ -7,7 +7,7 @@
     "id": "rEJBSTyZIrIb"
    },
    "source": [
-    "# Token Classification on IPUs - Fine-tuning"
+    "# Token Classification Task on IPU using BERT - Fine-tuning"
    ]
   },
   {

--- a/notebooks/translation.ipynb
+++ b/notebooks/translation.ipynb
@@ -7,7 +7,7 @@
     "id": "rEJBSTyZIrIb"
    },
    "source": [
-    "# Translation on IPUs - Fine-tuning"
+    "# Translation on IPU using BART-Base - Fine-tuning"
    ]
   },
   {

--- a/notebooks/wav2vec2/wav2vec2-fine-tuning-checkpoint.ipynb
+++ b/notebooks/wav2vec2/wav2vec2-fine-tuning-checkpoint.ipynb
@@ -6,7 +6,7 @@
    "id": "eb00796b",
    "metadata": {},
    "source": [
-    "# Fine-tune a wav2vec 2.0 Checkpoint for Automatic Speech Recognition on IPUs\n",
+    "# Automatic Speech Recognition (ASR) on IPU using wav2vec - Fine-tuning\n",
     "\n",
     "This notebook will demonstrate how to fine-tune a pre-trained wav2vec 2.0 model with PyTorch on Graphcore IPUs. We will use a `wav2vec2-base` model and fine-tune it for a CTC downstream task using the [LibriSpeech](https://huggingface.co/datasets/librispeech_asr) dataset.\n",
     "\n",
@@ -757,7 +757,7 @@
    "source": [
     "## Next steps\n",
     "\n",
-    "You can try out the notebook on [Running Automated Speech Recognition using a Fine-tuned wav2vec 2.0 Checkpoint on IPUs](https://github.com/huggingface/optimum-graphcore/blob/main/notebooks/wav2vec2/wav2vec2-inference-checkpoint.ipynb) to use the outputs of this notebook.\n",
+    "You can try out the notebook on [Automatic Speech Recognition (ASR) on IPU using wav2vec - Inference](https://github.com/huggingface/optimum-graphcore/blob/main/notebooks/wav2vec2/wav2vec2-inference-checkpoint.ipynb) to use the outputs of this notebook.\n",
     "\n",
     "Also, Try out the other [IPU-powered Jupyter Notebooks](https://www.graphcore.ai/ipu-jupyter-notebooks) to see how how IPUs perform on other tasks."
    ]

--- a/notebooks/wav2vec2/wav2vec2-inference-checkpoint.ipynb
+++ b/notebooks/wav2vec2/wav2vec2-inference-checkpoint.ipynb
@@ -6,7 +6,7 @@
    "id": "3f2aa9aa",
    "metadata": {},
    "source": [
-    "# Running Automated Speech Recognition using a Fine-tuned wav2vec 2.0 Checkpoint on IPUs\n",
+    "# Automatic Speech Recognition (ASR) on IPU using wav2vec - Inference\n",
     "\n",
     "This notebook will demonstrate how to perform wav2vec 2.0 inference with PyTorch on Graphcore IPUs. We will use a `wav2vec2-base` model fine-tuned for a connectionist temporal classification (CTC) downstream task using the [LibriSpeech](https://huggingface.co/datasets/librispeech_asr) dataset.\n",
     "\n",


### PR DESCRIPTION
This PR makes the titles of many notebooks consistent with their entries on the [IPU-powered Jupyter Notebooks](https://www.graphcore.ai/ipu-jupyter-notebooks) webpage. This makes it easier for a user to know that the link from the web page is taking them to the correct notebook.

The change is being made to the title to conform with the notebook titling convention described in the [Guidelines for Writing a Notebook](https://github.com/graphcore/examples/blob/master/utils/templates/notebook_guidelines.md#notebook-title).