### PR TITLE
Fix test assertion in test_trainer.py

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -713,7 +713,7 @@ class IPUTrainerIntegrationTest(TestCasePlus, IPUTrainerIntegrationCommon):
         trainer = get_regression_trainer(a=1.5, b=2.5, double_output=True, label_names=["labels"])
         preds = trainer.predict(trainer.eval_dataset).predictions
         x = trainer.eval_dataset.x
-        self.assertTrue(len(preds), 2)
+        self.assertEqual(len(preds), 2)
         self.assertTrue(np.allclose(preds[0], 1.5 * x + 2.5))
         self.assertTrue(np.allclose(preds[1], 1.5 * x + 2.5))
 


### PR DESCRIPTION
Fix: replace incorrect call to assertTrue with assertEqual

# What does this PR do?
As originally written, the call to `assertTrue` simply asserts that the `len(preds)` is a truthy value rather than comparing to the second argument.

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

